### PR TITLE
Add basic shop section

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -13,6 +13,7 @@ const postRoutes       = require("./routes/post");
 const userRoutes       = require("./routes/user");
 const paymentRoutes    = require("./routes/payment");
 const bookRoutes       = require("./routes/bookRoutes");
+const productRoutes    = require("./routes/productRoutes");
 
 const app  = express();
 const PORT = process.env.PORT || 5001;
@@ -49,6 +50,7 @@ app.use("/api/posts",       postRoutes);
 app.use("/api/users",       userRoutes);
 app.use("/api/payments",    paymentRoutes);
 app.use("/api/books",       bookRoutes);
+app.use("/api/products",    productRoutes);
 
 app.get("/", (_, res) => res.send("Server is working!"));
 

--- a/server/models/Product.js
+++ b/server/models/Product.js
@@ -1,0 +1,15 @@
+const mongoose = require('mongoose');
+
+const ProductSchema = new mongoose.Schema(
+    {
+        name: { type: String, required: true },
+        description: { type: String, default: '' },
+        price: { type: Number, default: 0 },
+        imageUrl: { type: String, default: '' },
+        saleActive: { type: Boolean, default: false },
+        salePrice: { type: Number, default: 0 },
+    },
+    { timestamps: true }
+);
+
+module.exports = mongoose.model('Product', ProductSchema);

--- a/server/routes/productRoutes.js
+++ b/server/routes/productRoutes.js
@@ -1,0 +1,110 @@
+const express = require('express');
+const router = express.Router();
+const fs = require('fs');
+const path = require('path');
+const multer = require('multer');
+const Product = require('../models/Product');
+
+const envUploadDir = process.env.UPLOAD_DIR || 'server/uploads';
+const uploadDir = path.isAbsolute(envUploadDir)
+    ? envUploadDir
+    : path.join(process.cwd(), envUploadDir);
+
+if (!fs.existsSync(uploadDir)) {
+    fs.mkdirSync(uploadDir, { recursive: true });
+}
+
+const storage = multer.diskStorage({
+    destination: (req, file, cb) => cb(null, uploadDir),
+    filename: (req, file, cb) => {
+        const safe = file.originalname
+            .normalize('NFD')
+            .replace(/[\u0300-\u036f]/g, '')
+            .replace(/\s+/g, '_')
+            .replace(/[^а-яА-ЯёЁa-zA-Z0-9.\-_]/g, '');
+        cb(null, Date.now() + '-' + safe);
+    },
+});
+const upload = multer({ storage, limits: { fileSize: 10 * 1024 * 1024 } });
+
+// Create product
+router.post('/', upload.single('image'), async (req, res) => {
+    try {
+        const { name, description, price, saleActive, salePrice } = req.body;
+        const imageUrl = req.file ? 'uploads/' + req.file.filename : '';
+        const newProduct = await Product.create({
+            name,
+            description,
+            price: Number(price) || 0,
+            imageUrl,
+            saleActive: saleActive === 'true',
+            salePrice: Number(salePrice) || 0,
+        });
+        res.json(newProduct);
+    } catch (err) {
+        console.error('Error creating product:', err);
+        res.status(500).json({ error: 'Server error while creating product.' });
+    }
+});
+
+// Get all products
+router.get('/', async (req, res) => {
+    try {
+        const products = await Product.find().sort({ createdAt: -1 });
+        res.json(products);
+    } catch (err) {
+        console.error('Error fetching products:', err);
+        res.status(500).json({ error: 'Server error while fetching products.' });
+    }
+});
+
+// Get one product
+router.get('/:id', async (req, res) => {
+    try {
+        const product = await Product.findById(req.params.id);
+        if (!product) return res.status(404).json({ error: 'Product not found.' });
+        res.json(product);
+    } catch (err) {
+        console.error('Error fetching single product:', err);
+        res.status(500).json({ error: 'Server error fetching that product.' });
+    }
+});
+
+// Update product
+router.put('/:id', upload.single('image'), async (req, res) => {
+    try {
+        const { name, description, price, saleActive, salePrice } = req.body;
+        let imageUrl;
+        if (req.file) {
+            imageUrl = 'uploads/' + req.file.filename;
+        }
+        const updatedData = {
+            name,
+            description,
+            price: Number(price) || 0,
+            saleActive: saleActive === 'true',
+            salePrice: Number(salePrice) || 0,
+        };
+        if (imageUrl) updatedData.imageUrl = imageUrl;
+        const product = await Product.findByIdAndUpdate(req.params.id, updatedData, { new: true });
+        if (!product) return res.status(404).json({ error: 'Product not found.' });
+        res.json(product);
+    } catch (err) {
+        console.error('Error updating product:', err);
+        res.status(500).json({ error: 'Server error updating product.' });
+    }
+});
+
+// Delete product
+router.delete('/:id', async (req, res) => {
+    try {
+        const product = await Product.findByIdAndDelete(req.params.id);
+        if (!product) return res.status(404).json({ error: 'Product not found.' });
+        res.json({ message: 'Product deleted successfully.' });
+    } catch (err) {
+        console.error('Error deleting product:', err);
+        res.status(500).json({ error: 'Server error deleting product.' });
+    }
+});
+
+module.exports = router;

--- a/src/app/components/AddToCartButton.tsx
+++ b/src/app/components/AddToCartButton.tsx
@@ -1,0 +1,16 @@
+"use client";
+import React from "react";
+import { Product } from "../context/CartContext";
+import { useCart } from "../context/CartContext";
+
+export default function AddToCartButton({ product }: { product: Product }) {
+    const { addItem } = useCart();
+    return (
+        <button
+            onClick={() => addItem(product)}
+            className="bg-[#1D9BF0] text-white px-6 py-2 rounded hover:opacity-90 hover:scale-[1.02] transition focus:outline-none focus:ring-2 focus:ring-[#1D9BF0]"
+        >
+            Сагсанд нэмэх
+        </button>
+    );
+}

--- a/src/app/context/CartContext.tsx
+++ b/src/app/context/CartContext.tsx
@@ -1,0 +1,80 @@
+"use client";
+import React, { createContext, useContext, useEffect, useState } from "react";
+
+export interface Product {
+    _id: string;
+    name: string;
+    description: string;
+    price: number;
+    imageUrl: string;
+    saleActive: boolean;
+    salePrice: number;
+}
+
+export interface CartItem {
+    product: Product;
+    quantity: number;
+}
+
+interface CartState {
+    items: CartItem[];
+    addItem: (p: Product) => void;
+    removeItem: (id: string) => void;
+    clearCart: () => void;
+}
+
+const CartContext = createContext<CartState>({
+    items: [],
+    addItem: () => {},
+    removeItem: () => {},
+    clearCart: () => {},
+});
+
+export function CartProvider({ children }: { children: React.ReactNode }) {
+    const [items, setItems] = useState<CartItem[]>([]);
+
+    useEffect(() => {
+        const stored = localStorage.getItem("cart");
+        if (stored) {
+            try {
+                setItems(JSON.parse(stored));
+            } catch {
+                /* ignore */
+            }
+        }
+    }, []);
+
+    useEffect(() => {
+        localStorage.setItem("cart", JSON.stringify(items));
+    }, [items]);
+
+    const addItem = (product: Product) => {
+        setItems((prev) => {
+            const existing = prev.find((c) => c.product._id === product._id);
+            if (existing) {
+                return prev.map((c) =>
+                    c.product._id === product._id
+                        ? { ...c, quantity: c.quantity + 1 }
+                        : c
+                );
+            }
+            return [...prev, { product, quantity: 1 }];
+        });
+    };
+
+    const removeItem = (id: string) => {
+        setItems((prev) => prev.filter((c) => c.product._id !== id));
+    };
+
+    const clearCart = () => setItems([]);
+
+    return (
+        <CartContext.Provider value={{ items, addItem, removeItem, clearCart }}>
+            {children}
+        </CartContext.Provider>
+    );
+}
+
+export function useCart() {
+    return useContext(CartContext);
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import "./globals.css";
 import { Inter } from "next/font/google";
 import { AuthProvider } from "./context/AuthContext";
+import { CartProvider } from "./context/CartContext";
 import Header from "./components/Header";
 import type { Metadata } from "next";
 import Link from "next/link";
@@ -69,6 +70,7 @@ export default function RootLayout({
         <body
             className={`${inter.className} flex flex-col min-h-screen bg-white text-gray-900`}
         >
+        <CartProvider>
         <AuthProvider>
             <div className="max-w-7xl w-full mx-auto md:px-6">
 
@@ -396,6 +398,7 @@ export default function RootLayout({
                 </p>
             </footer>
         </AuthProvider>
+        </CartProvider>
         </body>
         </html>
     );

--- a/src/app/shop/[productId]/page.tsx
+++ b/src/app/shop/[productId]/page.tsx
@@ -1,0 +1,86 @@
+"use client";
+import React, { useEffect, useState } from "react";
+import { useParams } from "next/navigation";
+import { Product } from "../../context/CartContext";
+import AddToCartButton from "../../components/AddToCartButton";
+
+export default function ProductDetailPage() {
+    const params = useParams();
+    const productId = params.productId as string;
+    const [product, setProduct] = useState<Product | null>(null);
+    const [status, setStatus] = useState("");
+    const BACKEND_URL = "https://www.vone.mn/api";
+
+    useEffect(() => {
+        const fetchProduct = async () => {
+            try {
+                const res = await fetch(`${BACKEND_URL}/products/${productId}`);
+                if (!res.ok) throw new Error("Failed to fetch product");
+                const data = await res.json();
+                setProduct(data);
+            } catch (error) {
+                console.error(error);
+                setStatus("Бараа дуудахад алдаа гарлаа!");
+            }
+        };
+        if (productId) fetchProduct();
+    }, [productId]);
+
+    if (!product) {
+        return (
+            <div className="min-h-screen bg-white text-black p-8">
+                <p className="text-center text-red-500">{status || "Уншиж байна..."}</p>
+            </div>
+        );
+    }
+
+    const finalPrice = product.saleActive ? product.salePrice : product.price;
+
+    return (
+        <main className="min-h-screen bg-white text-black py-8 px-4">
+            <div className="max-w-5xl mx-auto flex flex-col md:flex-row gap-10">
+                <div className="w-full md:w-1/2 bg-[#16181C] rounded flex items-center justify-center overflow-hidden">
+                    {product.imageUrl ? (
+                        <img
+                            src={`https://www.vone.mn/${product.imageUrl}`}
+                            alt={product.name}
+                            className="object-cover w-full h-auto hover:scale-[1.01] transition duration-300"
+                        />
+                    ) : (
+                        <p className="text-gray-500 p-4">No image available</p>
+                    )}
+                </div>
+                <div className="flex-1 flex flex-col space-y-6">
+                    <div className="space-y-2">
+                        <h1 className="text-3xl font-bold uppercase tracking-wide">{product.name}</h1>
+                    </div>
+                    <div className="text-sm text-black leading-relaxed">
+                        <h2 className="text-lg font-semibold mb-2 uppercase tracking-wider text-[#1D9BF0]">
+                            Танилцуулга
+                        </h2>
+                        <p>{product.description}</p>
+                    </div>
+                    <div className="border-t border-gray-700 pt-4 space-y-2">
+                        {product.saleActive ? (
+                            <div>
+                                <p className="text-md text-gray-500 line-through">
+                                    {product.price.toLocaleString("mn-MN")}₮
+                                </p>
+                                <p className="text-2xl font-bold text-red-500">
+                                    Хямдралтай: {product.salePrice.toLocaleString("mn-MN")}₮
+                                </p>
+                            </div>
+                        ) : (
+                            <p className="text-xl font-bold text-black">
+                                Үнэ: {finalPrice.toLocaleString("mn-MN")}₮
+                            </p>
+                        )}
+                        <div>
+                            <AddToCartButton product={product} />
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </main>
+    );
+}

--- a/src/app/shop/cart/page.tsx
+++ b/src/app/shop/cart/page.tsx
@@ -1,0 +1,60 @@
+"use client";
+import React from "react";
+import Link from "next/link";
+import { useCart } from "../../context/CartContext";
+
+export default function CartPage() {
+    const { items, removeItem, clearCart } = useCart();
+
+    const total = items.reduce((sum, item) => {
+        const price = item.product.saleActive ? item.product.salePrice : item.product.price;
+        return sum + price * item.quantity;
+    }, 0);
+
+    if (items.length === 0) {
+        return (
+            <main className="min-h-screen flex items-center justify-center">
+                <p className="text-gray-600">Сагс хоосон байна.</p>
+            </main>
+        );
+    }
+
+    return (
+        <main className="min-h-screen px-4 py-8">
+            <div className="max-w-2xl mx-auto space-y-6">
+                <h1 className="text-3xl font-bold text-center">Таны сагс</h1>
+                <ul className="space-y-4">
+                    {items.map((item) => (
+                        <li key={item.product._id} className="flex justify-between items-center border-b pb-2">
+                            <div>
+                                <p className="font-semibold">{item.product.name}</p>
+                                <p className="text-sm text-gray-500">Тоо: {item.quantity}</p>
+                            </div>
+                            <div className="flex items-center gap-4">
+                                <p>
+                                    {(
+                                        (item.product.saleActive ? item.product.salePrice : item.product.price) *
+                                        item.quantity
+                                    ).toLocaleString("mn-MN")}
+                                    ₮
+                                </p>
+                                <button onClick={() => removeItem(item.product._id)} className="text-red-500">
+                                    Устгах
+                                </button>
+                            </div>
+                        </li>
+                    ))}
+                </ul>
+                <p className="text-right font-bold">Нийт: {total.toLocaleString("mn-MN")}₮</p>
+                <div className="flex justify-between">
+                    <button onClick={clearCart} className="text-sm text-gray-600">
+                        Сагсыг цэвэрлэх
+                    </button>
+                    <Link href="/shop/checkout" className="bg-[#1D9BF0] text-white px-4 py-2 rounded">
+                        Төлбөр хийх
+                    </Link>
+                </div>
+            </div>
+        </main>
+    );
+}

--- a/src/app/shop/checkout/page.tsx
+++ b/src/app/shop/checkout/page.tsx
@@ -1,0 +1,57 @@
+"use client";
+import React, { useState } from "react";
+import { useCart } from "../../context/CartContext";
+import Link from "next/link";
+
+export default function CheckoutPage() {
+    const { items, clearCart } = useCart();
+    const [message, setMessage] = useState("");
+
+    const total = items.reduce((sum, item) => {
+        const price = item.product.saleActive ? item.product.salePrice : item.product.price;
+        return sum + price * item.quantity;
+    }, 0);
+
+    const handleCheckout = () => {
+        setMessage("Төлбөрийн заавар имэйлээр илгээгдлээ.");
+        clearCart();
+    };
+
+    if (items.length === 0) {
+        return (
+            <main className="min-h-screen flex items-center justify-center">
+                <p className="text-gray-600">Сагс хоосон байна.</p>
+            </main>
+        );
+    }
+
+    return (
+        <main className="min-h-screen px-4 py-8">
+            <div className="max-w-xl mx-auto space-y-6">
+                <h1 className="text-3xl font-bold text-center mb-4">Төлбөр хийх</h1>
+                <ul className="space-y-2">
+                    {items.map((item) => (
+                        <li key={item.product._id} className="flex justify-between">
+                            <span>{item.product.name} x {item.quantity}</span>
+                            <span>
+                                {(
+                                    (item.product.saleActive ? item.product.salePrice : item.product.price) *
+                                    item.quantity
+                                ).toLocaleString("mn-MN")}
+                                ₮
+                            </span>
+                        </li>
+                    ))}
+                </ul>
+                <p className="text-right font-bold">Нийт: {total.toLocaleString("mn-MN")}₮</p>
+                {message && <p className="text-green-600 text-center">{message}</p>}
+                <button onClick={handleCheckout} className="w-full bg-[#1D9BF0] text-white px-4 py-2 rounded">
+                    Захиалах
+                </button>
+                <Link href="/shop/cart" className="block text-center text-sm text-gray-600 mt-2">
+                    Буцах
+                </Link>
+            </div>
+        </main>
+    );
+}

--- a/src/app/shop/page.tsx
+++ b/src/app/shop/page.tsx
@@ -1,0 +1,84 @@
+"use client";
+import React, { useEffect, useState } from "react";
+import Link from "next/link";
+import { Product } from "../context/CartContext";
+
+export default function ShopPage() {
+    const [products, setProducts] = useState<Product[]>([]);
+    const [status, setStatus] = useState("");
+    const BACKEND_URL = "https://www.vone.mn/api";
+
+    useEffect(() => {
+        const fetchProducts = async () => {
+            try {
+                const res = await fetch(`${BACKEND_URL}/products`);
+                if (!res.ok) throw new Error("Failed to fetch");
+                const data = await res.json();
+                setProducts(data);
+            } catch (err) {
+                console.error(err);
+                setStatus("Бараа татаж чадсангүй!");
+            }
+        };
+        fetchProducts();
+    }, []);
+
+    return (
+        <main className="min-h-screen bg-white text-black px-4 py-8">
+            <div className="max-w-4xl mx-auto">
+                <h1 className="text-3xl font-bold mb-8 text-center tracking-wider uppercase">
+                    Дэлгүүр
+                </h1>
+                {status && <p className="text-red-500 mb-4 text-center">{status}</p>}
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
+                    {products.map((p) => {
+                        const finalPrice = p.saleActive ? p.salePrice : p.price;
+                        return (
+                            <Link
+                                key={p._id}
+                                href={`/shop/${p._id}`}
+                                className="group relative rounded-lg overflow-hidden border border-gray-200 bg-white hover:shadow-lg hover:shadow-[#1D9BF0]/30 hover:-translate-y-1 hover:scale-[1.01] transition-transform duration-300 flex flex-col"
+                            >
+                                {p.imageUrl ? (
+                                    <div className="relative w-full aspect-[3/4] overflow-hidden bg-white">
+                                        <img
+                                            src={`https://www.vone.mn/${p.imageUrl}`}
+                                            alt={p.name}
+                                            className="w-full h-full object-cover group-hover:opacity-90 group-hover:scale-105 transition duration-300"
+                                        />
+                                    </div>
+                                ) : (
+                                    <div className="w-full aspect-[3/4] bg-[#222] flex items-center justify-center text-gray-500">
+                                        No Image
+                                    </div>
+                                )}
+                                <div className="p-4 flex flex-col flex-1">
+                                    <h2 className="text-lg font-semibold uppercase tracking-wide mb-1 line-clamp-1">
+                                        {p.name}
+                                    </h2>
+                                    <p className="text-sm text-gray-300 mb-3 line-clamp-2">
+                                        {p.description}
+                                    </p>
+                                    {p.saleActive ? (
+                                        <div className="mt-auto space-y-1">
+                                            <p className="text-sm text-gray-500 line-through">
+                                                {p.price.toLocaleString("mn-MN")}₮
+                                            </p>
+                                            <p className="text-lg font-bold text-red-500">
+                                                {p.salePrice.toLocaleString("mn-MN")}₮
+                                            </p>
+                                        </div>
+                                    ) : (
+                                        <p className="mt-auto text-lg font-bold text-black">
+                                            {finalPrice.toLocaleString("mn-MN")}₮
+                                        </p>
+                                    )}
+                                </div>
+                            </Link>
+                        );
+                    })}
+                </div>
+            </div>
+        </main>
+    );
+}


### PR DESCRIPTION
## Summary
- add Product model and routes to server for CRUD
- enable productRoutes in server
- implement CartContext and AddToCartButton
- wrap layout in CartProvider
- add shop pages: listing, product detail, cart, and checkout

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846ace1aee0832887061c3d8fa25cc2