### PR TITLE
Apply dark mode styles across pages

### DIFF
--- a/src/app/book/[bookId]/page.tsx
+++ b/src/app/book/[bookId]/page.tsx
@@ -40,7 +40,7 @@ export default function BookDetailPage() {
 
     if (!book) {
         return (
-            <div className="min-h-screen bg-black text-black p-8">
+            <div className="min-h-screen bg-black text-black dark:text-white p-8">
                 <p className="text-center text-red-500">{status || "Уншиж байна..."}</p>
             </div>
         );
@@ -49,7 +49,7 @@ export default function BookDetailPage() {
     const finalPrice = book.saleActive ? book.salePrice : book.price;
 
     return (
-        <main className="min-h-screen bg-white text-black py-8 px-4">
+        <main className="min-h-screen bg-white dark:bg-dark text-black dark:text-white py-8 px-4">
             <div className="max-w-5xl mx-auto flex flex-col md:flex-row gap-10">
                 <div className="w-full md:w-1/2 bg-[#16181C] rounded flex items-center justify-center overflow-hidden">
                     {book.coverImageUrl ? (
@@ -67,7 +67,7 @@ export default function BookDetailPage() {
                         <h1 className="text-3xl font-bold uppercase tracking-wide">{book.title}</h1>
                         <p className="text-gray-400 text-sm">Зохиогч: {book.author}</p>
                     </div>
-                    <div className="text-sm text-black leading-relaxed">
+                    <div className="text-sm text-black dark:text-white leading-relaxed">
                         <h2 className="text-lg font-semibold mb-2 uppercase tracking-wider text-[#1D9BF0]">
                             Номын Танилцуулга
                         </h2>
@@ -84,7 +84,7 @@ export default function BookDetailPage() {
                                 </p>
                             </div>
                         ) : (
-                            <p className="text-xl font-bold text-black">
+                            <p className="text-xl font-bold text-black dark:text-white">
                                 Үнэ: {finalPrice.toLocaleString("mn-MN")}₮
                             </p>
                         )}

--- a/src/app/book/page.tsx
+++ b/src/app/book/page.tsx
@@ -35,7 +35,7 @@ export default function BooksListPage() {
     }, []);
 
     return (
-        <main className="min-h-screen bg-white text-black px-4 py-8">
+        <main className="min-h-screen bg-white dark:bg-dark text-black dark:text-white px-4 py-8">
             <div className="max-w-4xl mx-auto">
                 <h1 className="text-3xl font-bold mb-8 text-center tracking-wider uppercase">
                     Бүх Ном
@@ -49,10 +49,10 @@ export default function BooksListPage() {
                             <Link
                                 key={book._id}
                                 href={`/book/${book._id}`}
-                                className="group relative rounded-lg overflow-hidden border border-gray-200 bg-white hover:shadow-lg hover:shadow-[#1D9BF0]/30 hover:-translate-y-1 hover:scale-[1.01] transition-transform duration-300 flex flex-col"
+                                className="group relative rounded-lg overflow-hidden border border-gray-200 bg-white dark:bg-gray-800 hover:shadow-lg hover:shadow-[#1D9BF0]/30 hover:-translate-y-1 hover:scale-[1.01] transition-transform duration-300 flex flex-col"
                             >
                                 {book.coverImageUrl ? (
-                                    <div className="relative w-full aspect-[3/4] overflow-hidden bg-white">
+                                    <div className="relative w-full aspect-[3/4] overflow-hidden bg-white dark:bg-gray-700">
                                         <img
                                             src={`https://www.vone.mn/api/${book.coverImageUrl}`}
                                             alt={book.title}
@@ -85,7 +85,7 @@ export default function BooksListPage() {
                                             </p>
                                         </div>
                                     ) : (
-                                        <p className="mt-auto text-lg font-bold text-black">
+                                        <p className="mt-auto text-lg font-bold text-black dark:text-white">
                                             {finalPrice.toLocaleString("mn-MN")}₮
                                         </p>
                                     )}

--- a/src/app/components/BottomNav.tsx
+++ b/src/app/components/BottomNav.tsx
@@ -16,13 +16,13 @@ const BottomNav: React.FC = () => {
 
     return (
         <nav
-            className="fixed bottom-0 left-0 w-full bg-white border-t border-gray-200 z-50 shadow-sm"
+            className="fixed bottom-0 left-0 w-full bg-white dark:bg-gray-800 border-t border-gray-200 dark:border-gray-700 z-50 shadow-sm"
         >
             <div className="flex justify-around items-center py-3 sm:py-4">
                 {/* HOME */}
                 <button
                     onClick={() => router.push("/")}
-                    className="flex flex-col items-center text-black hover:text-gray-600 transition p-1"
+                    className="flex flex-col items-center text-black dark:text-gray-300 hover:text-gray-600 dark:hover:text-gray-100 transition p-1"
                 >
                     <HomeIcon className="h-6 w-6 sm:h-7 sm:w-7" />
                 </button>
@@ -30,20 +30,20 @@ const BottomNav: React.FC = () => {
                 {/* TIME */}
                 <button
                     onClick={() => router.push("/orders")}
-                    className="flex flex-col items-center text-black hover:text-gray-600 transition p-1"
+                    className="flex flex-col items-center text-black dark:text-gray-300 hover:text-gray-600 dark:hover:text-gray-100 transition p-1"
                 >
                     <ClockIcon className="h-6 w-6 sm:h-7 sm:w-7" />
                 </button>
                 <button
                     onClick={() => router.push("/orders")}
-                    className="flex flex-col items-center text-black hover:text-gray-600 transition p-1"
+                    className="flex flex-col items-center text-black dark:text-gray-300 hover:text-gray-600 dark:hover:text-gray-100 transition p-1"
                 >
                     <ShoppingBagIcon className="h-6 w-6 sm:h-7 sm:w-7" />
                 </button>
                 {/* PROFILE */}
                 <button
                     onClick={() => router.push("/profile")}
-                    className="flex flex-col items-center text-black hover:text-gray-600 transition p-1"
+                    className="flex flex-col items-center text-black dark:text-gray-300 hover:text-gray-600 dark:hover:text-gray-100 transition p-1"
                 >
                     <UserCircleIcon className="h-6 w-6 sm:h-7 sm:w-7" />
                 </button>

--- a/src/app/components/FAQSection.tsx
+++ b/src/app/components/FAQSection.tsx
@@ -18,15 +18,15 @@ const SingleFAQItem: React.FC<FAQItemProps> = ({
     return (
         <div
             onClick={onClick}
-            className="border-b border-gray-200 cursor-pointer py-4 hover:bg-gray-50 transition"
+            className="border-b border-gray-200 dark:border-gray-700 cursor-pointer py-4 hover:bg-gray-50 dark:hover:bg-gray-800 transition"
         >
             <div className="flex items-center justify-between">
-                <h3 className="font-semibold text-base md:text-lg text-gray-900">
+                <h3 className="font-semibold text-base md:text-lg text-gray-900 dark:text-white">
                     {question}
                 </h3>
                 <motion.span
                     animate={{ rotate: isActive ? 45 : 0 }}
-                    className="text-gray-500 text-xl"
+                    className="text-gray-500 dark:text-gray-400 text-xl"
                 >
                     +
                 </motion.span>
@@ -38,7 +38,7 @@ const SingleFAQItem: React.FC<FAQItemProps> = ({
                         animate={{ height: "auto", opacity: 1 }}
                         exit={{ height: 0, opacity: 0 }}
                         transition={{ duration: 0.3 }}
-                        className="pt-3 text-sm md:text-base text-gray-700"
+                        className="pt-3 text-sm md:text-base text-gray-700 dark:text-gray-300"
                     >
                         {answer}
                     </motion.div>
@@ -89,7 +89,7 @@ const FAQSection = () => {
     };
 
     return (
-        <div className="w-full bg-white py-14 px-4">
+        <div className="w-full bg-white dark:bg-gray-900 py-14 px-4">
             {/* Title & Subtitle */}
             <motion.div
                 initial={{ opacity: 0, y: 20 }}

--- a/src/app/components/Footer.tsx
+++ b/src/app/components/Footer.tsx
@@ -5,7 +5,7 @@ import Link from "next/link";
 
 const Footer: React.FC = () => {
     return (
-        <footer className="bg-gray-100 text-gray-600 py-6 mt-8">
+        <footer className="bg-gray-100 dark:bg-gray-900 text-gray-600 dark:text-gray-300 py-6 mt-8">
             <div className="max-w-7xl mx-auto px-4 flex flex-col sm:flex-row sm:items-center sm:justify-between">
                 {/* Copyright Text */}
                 <p className="text-sm mb-2 sm:mb-0">

--- a/src/app/components/Header.tsx
+++ b/src/app/components/Header.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import Image from "next/image";
 import logo from "@/app/img/logo.svg";
 import { useAuth } from "../context/AuthContext";
+import ThemeToggle from "./ThemeToggle";
 
 export default function Header() {
     const [isMenuOpen, setIsMenuOpen] = useState(false);
@@ -20,7 +21,7 @@ export default function Header() {
                 `}</style>
             )}
 
-            <div className="fixed top-0 left-0 w-full z-[999] bg-white md:bg-white/80 backdrop-blur-md">
+            <div className="fixed top-0 left-0 w-full z-[999] bg-white dark:bg-dark md:bg-white/80 dark:md:bg-dark/80 backdrop-blur-md">
                 {/* NAV BAR */}
                 <nav className="max-w-7xl mx-auto px-6 py-4 flex items-center justify-between">
                     {/* Logo */}
@@ -30,15 +31,16 @@ export default function Header() {
                             alt="Лого"
                             className="h-8 w-auto object-contain transition-transform hover:scale-105"
                         />
-                        <span className="text-black font-bold text-lg">Vone</span>
+                        <span className="text-black dark:text-white font-bold text-lg">Vone</span>
                     </Link>
 
                     {/* Desktop Links */}
                     <div className="hidden md:flex items-center space-x-8 font-medium">
+                        <ThemeToggle />
                         {loggedIn ? (
                             <button
                                 onClick={logout}
-                                className="relative group text-gray-700 hover:text-[#1D9BF0]"
+                                className="relative group text-gray-700 dark:text-gray-300 hover:text-[#1D9BF0]"
                             >
                                 Гарах
                                 <span className="absolute left-0 bottom-0 w-full h-0.5 bg-[#1D9BF0] scale-x-0 group-hover:scale-x-100 transition-transform origin-left" />
@@ -47,14 +49,14 @@ export default function Header() {
                             <>
                                 <Link
                                     href="/login"
-                                    className="relative group text-gray-700 hover:text-[#1D9BF0]"
+                                    className="relative group text-gray-700 dark:text-gray-300 hover:text-[#1D9BF0]"
                                 >
                                     Нэвтрэх
                                     <span className="absolute left-0 bottom-0 w-full h-0.5 bg-[#1D9BF0] scale-x-0 group-hover:scale-x-100 transition-transform origin-left" />
                                 </Link>
                                 <Link
                                     href="/register"
-                                    className="relative group text-gray-700 hover:text-[#1D9BF0]"
+                                    className="relative group text-gray-700 dark:text-gray-300 hover:text-[#1D9BF0]"
                                 >
                                     Бүртгүүлэх
                                     <span className="absolute left-0 bottom-0 w-full h-0.5 bg-[#1D9BF0] scale-x-0 group-hover:scale-x-100 transition-transform origin-left" />
@@ -69,9 +71,9 @@ export default function Header() {
                         onClick={() => setIsMenuOpen(true)}
                         aria-label="Toggle Menu"
                     >
-                        <span className="block w-6 h-0.5 bg-gray-800 mb-1" />
-                        <span className="block w-6 h-0.5 bg-gray-800 mb-1" />
-                        <span className="block w-6 h-0.5 bg-gray-800" />
+                        <span className="block w-6 h-0.5 bg-gray-800 dark:bg-gray-200 mb-1" />
+                        <span className="block w-6 h-0.5 bg-gray-800 dark:bg-gray-200 mb-1" />
+                        <span className="block w-6 h-0.5 bg-gray-800 dark:bg-gray-200" />
                     </button>
                 </nav>
 
@@ -79,7 +81,7 @@ export default function Header() {
                 <div
                     className={`
             fixed inset-0
-            bg-white
+            bg-white dark:bg-dark
             transition-transform duration-300
             z-[9999]
             overflow-y-auto
@@ -102,7 +104,7 @@ export default function Header() {
                                 />
                             </Link>
                             <button
-                                className="text-gray-500 text-3xl focus:outline-none hover:text-gray-700"
+                                className="text-gray-500 dark:text-gray-400 text-3xl focus:outline-none hover:text-gray-700 dark:hover:text-gray-200"
                                 onClick={() => setIsMenuOpen(false)}
                                 aria-label="Close Menu"
                             >
@@ -113,6 +115,9 @@ export default function Header() {
                         {/* Drawer Links */}
                         <nav className="mt-8 px-4">
                             <ul className="space-y-6">
+                                <li>
+                                    <ThemeToggle />
+                                </li>
                                 {loggedIn ? (
                                     <li>
                                         <button
@@ -120,7 +125,7 @@ export default function Header() {
                                                 logout();
                                                 setIsMenuOpen(false);
                                             }}
-                                            className="block text-left w-full text-xl font-medium text-gray-800 hover:text-[#1D9BF0]"
+                                            className="block text-left w-full text-xl font-medium text-gray-800 dark:text-gray-200 hover:text-[#1D9BF0]"
                                         >
                                             Гарах
                                         </button>
@@ -131,7 +136,7 @@ export default function Header() {
                                             <Link
                                                 href="/login"
                                                 onClick={() => setIsMenuOpen(false)}
-                                                className="block text-xl font-medium text-gray-800 hover:text-[#1D9BF0]"
+                                                className="block text-xl font-medium text-gray-800 dark:text-gray-200 hover:text-[#1D9BF0]"
                                             >
                                                 Нэвтрэх
                                             </Link>
@@ -140,7 +145,7 @@ export default function Header() {
                                             <Link
                                                 href="/register"
                                                 onClick={() => setIsMenuOpen(false)}
-                                                className="block text-xl font-medium text-gray-800 hover:text-[#1D9BF0]"
+                                                className="block text-xl font-medium text-gray-800 dark:text-gray-200 hover:text-[#1D9BF0]"
                                             >
                                                 Бүртгүүлэх
                                             </Link>
@@ -151,7 +156,7 @@ export default function Header() {
 
                             {/* Additional Nav Items */}
                             <div className="mt-10 border-t pt-6">
-                                <ul className="space-y-4 text-lg font-semibold text-gray-700">
+                                <ul className="space-y-4 text-lg font-semibold text-gray-700 dark:text-gray-300">
                                     <li>
                                         <Link
                                             href="/"

--- a/src/app/components/Modal.tsx
+++ b/src/app/components/Modal.tsx
@@ -17,14 +17,14 @@ const Modal: React.FC<ModalProps> = ({ children, onClose }) => {
                 exit={{ opacity: 0 }}
             >
                 <motion.div
-                    className="bg-white square-card overflow-hidden shadow-lg max-w-lg w-full"
+                    className="bg-white dark:bg-gray-800 square-card overflow-hidden shadow-lg max-w-lg w-full"
                     initial={{ scale: 0.8, opacity: 0 }}
                     animate={{ scale: 1, opacity: 1 }}
                     exit={{ scale: 0.8, opacity: 0 }}
                     transition={{ duration: 0.3 }}
                 >
                     <div className="flex justify-end p-2">
-                        <button onClick={onClose} className="text-gray-600 hover:text-gray-800">
+                        <button onClick={onClose} className="text-gray-600 dark:text-gray-300 hover:text-gray-800 dark:hover:text-gray-100">
                             <FaTimes size={20} />
                         </button>
                     </div>

--- a/src/app/components/SubscriptionPage.tsx
+++ b/src/app/components/SubscriptionPage.tsx
@@ -94,7 +94,7 @@ export default function SubscriptionPage() {
     };
 
     return (
-        <div className="max-w-xl mx-auto p-4 text-white">
+        <div className="max-w-xl mx-auto p-4 text-white bg-dark">
             <h1 className="text-2xl font-bold mb-4 text-center">
                 Сарын Гишүүнчлэл
             </h1>

--- a/src/app/components/ThemeToggle.tsx
+++ b/src/app/components/ThemeToggle.tsx
@@ -1,0 +1,20 @@
+"use client";
+import { MoonIcon, SunIcon } from "@heroicons/react/24/outline";
+import { useTheme } from "../context/ThemeContext";
+
+export default function ThemeToggle() {
+    const { theme, toggleTheme } = useTheme();
+    return (
+        <button
+            onClick={toggleTheme}
+            aria-label="Toggle Theme"
+            className="p-2 rounded transition-colors hover:bg-gray-200 dark:hover:bg-gray-700"
+        >
+            {theme === "dark" ? (
+                <SunIcon className="w-6 h-6 text-yellow-400" />
+            ) : (
+                <MoonIcon className="w-6 h-6 text-gray-800" />
+            )}
+        </button>
+    );
+}

--- a/src/app/context/ThemeContext.tsx
+++ b/src/app/context/ThemeContext.tsx
@@ -1,0 +1,43 @@
+"use client";
+import { createContext, useContext, useEffect, useState } from "react";
+
+export type Theme = "light" | "dark";
+
+interface ThemeState {
+    theme: Theme;
+    toggleTheme: () => void;
+}
+
+const ThemeContext = createContext<ThemeState>({
+    theme: "light",
+    toggleTheme: () => {},
+});
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+    const [theme, setTheme] = useState<Theme>("light");
+
+    useEffect(() => {
+        const stored = localStorage.getItem("theme");
+        if (stored === "dark" || stored === "light") {
+            setTheme(stored);
+            document.documentElement.classList.toggle("dark", stored === "dark");
+        }
+    }, []);
+
+    const toggleTheme = () => {
+        const next = theme === "light" ? "dark" : "light";
+        setTheme(next);
+        localStorage.setItem("theme", next);
+        document.documentElement.classList.toggle("dark", next === "dark");
+    };
+
+    return (
+        <ThemeContext.Provider value={{ theme, toggleTheme }}>
+            {children}
+        </ThemeContext.Provider>
+    );
+}
+
+export function useTheme() {
+    return useContext(ThemeContext);
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -13,7 +13,15 @@ body {
     padding: 0;
     margin: 0;
     font-family: "Poppins", sans-serif;
-    background-color: inherit;
+}
+
+html {
+    background-color: #ffffff;
+}
+
+html.dark {
+    background-color: #080808;
+    color-scheme: dark;
 }
 
 /* Minimal fade-in-up animation for sidebars */

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import "./globals.css";
 import { Inter } from "next/font/google";
 import { AuthProvider } from "./context/AuthContext";
 import { CartProvider } from "./context/CartContext";
+import { ThemeProvider } from "./context/ThemeContext";
 import Header from "./components/Header";
 import type { Metadata } from "next";
 import Link from "next/link";
@@ -68,8 +69,9 @@ export default function RootLayout({
     return (
         <html lang="mn">
         <body
-            className={`${inter.className} flex flex-col min-h-screen bg-white text-gray-900`}
+            className={`${inter.className} flex flex-col min-h-screen bg-white text-gray-900 dark:bg-dark dark:text-white`}
         >
+        <ThemeProvider>
         <CartProvider>
         <AuthProvider>
             <div className="max-w-7xl w-full mx-auto md:px-6">
@@ -399,6 +401,7 @@ export default function RootLayout({
             </footer>
         </AuthProvider>
         </CartProvider>
+        </ThemeProvider>
         </body>
         </html>
     );

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -34,18 +34,18 @@ export default function LoginPage() {
     };
 
     return (
-        <div className="min-h-screen bg-white flex items-center justify-center px-4">
+        <div className="min-h-screen bg-white dark:bg-dark text-black dark:text-white flex items-center justify-center px-4">
             <div className="w-full max-w-md space-y-6">
-                <h1 className="text-3xl font-bold text-black">Нэвтрэх</h1>
+                <h1 className="text-3xl font-bold text-black dark:text-white">Нэвтрэх</h1>
                 {error && <p className="text-red-600">{error}</p>}
                 <form onSubmit={handleSubmit} className="space-y-6">
                     <div>
-                        <label className="block text-sm font-medium text-black mb-1">
+                        <label className="block text-sm font-medium text-black dark:text-white mb-1">
                             Хэрэглэгчийн нэр
                         </label>
                         <input
                             type="text"
-                            className="w-full border border-gray-300 rounded-md px-3 py-2 text-black bg-white focus:outline-none focus:ring-2 focus:ring-blue-500"
+                            className="w-full border border-gray-300 dark:border-gray-600 rounded-md px-3 py-2 text-black dark:text-white bg-white dark:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-blue-500"
                             placeholder="Хэрэглэгчийн нэр"
                             value={username}
                             onChange={(e) => setUsername(e.target.value)}
@@ -53,20 +53,20 @@ export default function LoginPage() {
                         />
                     </div>
                     <div>
-                        <label className="block text-sm font-medium text-black mb-1">
+                        <label className="block text-sm font-medium text-black dark:text-white mb-1">
                             Нууц үг
                         </label>
                         <input
                             type="password"
-                            className="w-full border border-gray-300 rounded-md px-3 py-2 text-black bg-white focus:outline-none focus:ring-2 focus:ring-blue-500"
+                            className="w-full border border-gray-300 dark:border-gray-600 rounded-md px-3 py-2 text-black dark:text-white bg-white dark:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-blue-500"
                             placeholder="Нууц үг"
                             value={password}
                             onChange={(e) => setPassword(e.target.value)}
                             required
                         />
                     </div>
-                    <div className="flex items-center justify-between text-sm text-gray-700">
-                        <label className="flex items-center text-black">
+                    <div className="flex items-center justify-between text-sm text-gray-700 dark:text-gray-300">
+                        <label className="flex items-center text-black dark:text-white">
                             <input type="checkbox" className="h-4 w-4 mr-2" />
                             Сануулах
                         </label>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -191,7 +191,7 @@ export default function HomePage() {
     }, [fetchPosts]);
 
     return (
-        <div className="min-h-screen bg-gray-100 text-gray-900">
+        <div className="min-h-screen bg-gray-100 dark:bg-dark text-gray-900 dark:text-white">
             {/* Outer Grid Layout */}
             <div
                 className="mx-auto max-w-5xl w-full grid"
@@ -202,7 +202,7 @@ export default function HomePage() {
             >
                 {/* Sidebar: Trending Hashtags */}
                 <aside>
-                    <div className="bg-white p-4 grid gap-3">
+                    <div className="bg-white dark:bg-gray-800 p-4 grid gap-3">
                         <div className="grid grid-cols-[auto,1fr] items-center gap-2">
                             <FiCamera className="w-5 h-5 text-[#1D9BF0]" />
                             <h2 className="text-base font-semibold">Trending Hashtags</h2>
@@ -215,7 +215,7 @@ export default function HomePage() {
                             }}
                         >
                             <button
-                                className="px-3 py-1 text-xs bg-gray-200 rounded-full hover:bg-gray-300"
+                                className="px-3 py-1 text-xs bg-gray-200 dark:bg-gray-700 rounded-full hover:bg-gray-300 dark:hover:bg-gray-600"
                                 onClick={() => filterPostsByHashtag("")}
                             >
                                 Бүх
@@ -223,7 +223,7 @@ export default function HomePage() {
                             {trendingHashtags.map((hashtag) => (
                                 <button
                                     key={hashtag.tag}
-                                    className="px-3 py-1 text-xs bg-gray-200 rounded-full hover:bg-gray-300"
+                                    className="px-3 py-1 text-xs bg-gray-200 dark:bg-gray-700 rounded-full hover:bg-gray-300 dark:hover:bg-gray-600"
                                     onClick={() => filterPostsByHashtag(hashtag.tag)}
                                 >
                                     {hashtag.tag} ({hashtag.count})
@@ -236,7 +236,7 @@ export default function HomePage() {
                 {/* Main Content: Create Post & Posts List */}
                 <main>
                     {loggedIn && (
-                        <div className="bg-white grid gap-4 p-6">
+                        <div className="bg-white dark:bg-gray-800 grid gap-4 p-6">
                             <div className="grid grid-cols-[auto,1fr] items-center gap-2">
                                 <input
                                     type="file"
@@ -247,9 +247,9 @@ export default function HomePage() {
                                 />
                                 <button
                                     onClick={triggerFileInput}
-                                    className="p-2 border border-gray-200 rounded-full hover:bg-gray-100"
+                                    className="p-2 border border-gray-200 dark:border-gray-600 rounded-full hover:bg-gray-100 dark:hover:bg-gray-700"
                                 >
-                                    <FiCamera className="w-5 h-5 text-gray-600" />
+                                    <FiCamera className="w-5 h-5 text-gray-600 dark:text-gray-400" />
                                 </button>
                                 {imageFile && (
                                     <span className="text-xs text-gray-700 truncate">
@@ -259,7 +259,7 @@ export default function HomePage() {
                             </div>
                             <textarea
                                 placeholder="What's on your mind?"
-                                className="w-full text-sm text-gray-900 border border-gray-200 rounded p-2 focus:outline-none"
+                                className="w-full text-sm text-gray-900 dark:text-white border border-gray-200 dark:border-gray-600 rounded p-2 focus:outline-none"
                                 rows={3}
                                 value={content}
                                 onChange={(e) => setContent(e.target.value)}
@@ -284,7 +284,7 @@ export default function HomePage() {
                                     initial={{ opacity: 0, y: 20 }}
                                     animate={{ opacity: 1, y: 0 }}
                                     transition={{ delay: idx * 0.02 }}
-                                    className="bg-white p-6 grid gap-4 border-b border-gray-200"
+                                    className="bg-white dark:bg-gray-800 p-6 grid gap-4 border-b border-gray-200 dark:border-gray-700"
                                 >
                                     <div className="grid grid-cols-[auto,1fr] gap-5">
                                         {/* Profile Picture with Skeleton Fallback */}
@@ -331,7 +331,7 @@ export default function HomePage() {
                                                     </div>
                                                 )}
                                             </div>
-                                            <span className="text-xs text-gray-500">
+                                            <span className="text-xs text-gray-500 dark:text-gray-400">
                                                 {new Date(post.createdAt).toLocaleString()}
                                             </span>
                                             {post.content && (
@@ -354,7 +354,7 @@ export default function HomePage() {
                                         </div>
                                     </div>
                                     {/* Stats Row */}
-                                    <div className="grid grid-cols-3 items-center text-xs text-gray-600 w-full mt-2">
+                                    <div className="grid grid-cols-3 items-center text-xs text-gray-600 dark:text-gray-400 w-full mt-2">
                                         {/* Like */}
                                         <button
                                             onClick={() => handleLike(post._id)}

--- a/src/app/profile/[id]/page.tsx
+++ b/src/app/profile/[id]/page.tsx
@@ -87,9 +87,9 @@ export default function PublicProfilePage() {
 
     // ---------------- UI ----------------
     return (
-        <div className="min-h-screen bg-white px-4 py-6 flex flex-col items-center">
+        <div className="min-h-screen bg-white dark:bg-dark text-black dark:text-white px-4 py-6 flex flex-col items-center">
             {/* Profile Header */}
-            <div className="w-full max-w-xl bg-white rounded-md shadow-sm p-6 flex flex-col items-center">
+            <div className="w-full max-w-xl bg-white dark:bg-gray-800 rounded-md shadow-sm p-6 flex flex-col items-center">
                 {/* Profile Picture */}
                 <div className="relative w-32 h-32 mb-4">
                     {userData.profilePicture ? (
@@ -99,7 +99,7 @@ export default function PublicProfilePage() {
                             className="w-32 h-32 rounded-full object-cover border border-gray-300"
                         />
                     ) : (
-                        <div className="w-32 h-32 rounded-full bg-gray-200" />
+                        <div className="w-32 h-32 rounded-full bg-gray-200 dark:bg-gray-700" />
                     )}
                 </div>
 
@@ -117,16 +117,16 @@ export default function PublicProfilePage() {
                 {/* Follower/Following Stats */}
                 <div className="flex items-center gap-6 mt-4">
                     <div className="text-center">
-                        <p className="text-lg font-semibold text-gray-800">
+                        <p className="text-lg font-semibold text-gray-800 dark:text-gray-200">
                             {userData.followers ? userData.followers.length : 0}
                         </p>
-                        <p className="text-sm text-gray-500">Followers</p>
+                        <p className="text-sm text-gray-500 dark:text-gray-400">Followers</p>
                     </div>
                     <div className="text-center">
-                        <p className="text-lg font-semibold text-gray-800">
+                        <p className="text-lg font-semibold text-gray-800 dark:text-gray-200">
                             {userData.following ? userData.following.length : 0}
                         </p>
-                        <p className="text-sm text-gray-500">Following</p>
+                        <p className="text-sm text-gray-500 dark:text-gray-400">Following</p>
                     </div>
                 </div>
             </div>
@@ -137,25 +137,25 @@ export default function PublicProfilePage() {
                     Нийтлэлүүд
                 </h2>
                 {postLoading && (
-                    <p className="text-gray-600 mb-2">Ачааллаж байна...</p>
+                    <p className="text-gray-600 dark:text-gray-400 mb-2">Ачааллаж байна...</p>
                 )}
                 {!postLoading && userPosts.length === 0 && (
-                    <p className="text-gray-600">Энэ хэрэглэгч нийтлэлгүй байна.</p>
+                    <p className="text-gray-600 dark:text-gray-400">Энэ хэрэглэгч нийтлэлгүй байна.</p>
                 )}
                 <div className="space-y-4">
                     {userPosts.map((post) => (
                         <div
                             key={post._id}
-                            className="p-4 bg-white rounded-md shadow-sm border border-gray-100"
+                            className="p-4 bg-white dark:bg-gray-800 rounded-md shadow-sm border border-gray-100 dark:border-gray-700"
                         >
                             {/* Post Title */}
-                            <h3 className="text-md font-bold text-gray-800 mb-1">
+                            <h3 className="text-md font-bold text-gray-800 dark:text-gray-200 mb-1">
                                 {post.title}
                             </h3>
                             {/* Post Content */}
-                            <p className="text-sm text-gray-700 mb-2">{post.content}</p>
+                            <p className="text-sm text-gray-700 dark:text-gray-300 mb-2">{post.content}</p>
                             {/* Post Date */}
-                            <p className="text-xs text-gray-400">
+                            <p className="text-xs text-gray-400 dark:text-gray-500">
                                 {new Date(post.createdAt).toLocaleString()}
                             </p>
                         </div>

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -99,7 +99,7 @@ export default function MyOwnProfilePage() {
 
     // ---------------- UI ----------------
     return (
-        <div className="min-h-screen bg-white font-sans">
+        <div className="min-h-screen bg-white dark:bg-dark text-black dark:text-white font-sans">
             {/* My Profile Header */}
             <div className="text-center p-5 border-b border-gray-200">
                 {/* Profile Picture */}

--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -228,26 +228,26 @@ export default function RegisterMultiStepPage() {
 
     // ---------- Utility: conditional className for inputs/selects ----------
     const getInputClass = (fieldName: string) => {
-        return `w-full rounded-md px-3 py-2 text-black bg-white focus:outline-none focus:ring-2 ${
+        return `w-full rounded-md px-3 py-2 text-black dark:text-white bg-white dark:bg-gray-800 focus:outline-none focus:ring-2 ${
             fieldErrors[fieldName]
                 ? "border border-red-500 focus:ring-red-500"
-                : "border border-gray-300 focus:ring-blue-500"
+                : "border border-gray-300 dark:border-gray-600 focus:ring-blue-500"
         }`;
     };
 
     return (
-        <div className="min-h-screen bg-white flex items-center justify-center px-4">
+        <div className="min-h-screen bg-white dark:bg-dark text-black dark:text-white flex items-center justify-center px-4">
             <div className="w-full max-w-md space-y-6">
                 {error && <p className="text-red-600">{error}</p>}
                 {success && <p className="text-green-600">{success}</p>}
 
                 {step === 1 && (
                     <form onSubmit={(e) => e.preventDefault()} className="space-y-6">
-                        <h1 className="text-3xl font-bold text-black">Create your account</h1>
+                        <h1 className="text-3xl font-bold text-black dark:text-white">Create your account</h1>
 
                         {/* USERNAME */}
                         <div>
-                            <label className="block font-medium text-black mb-1">Username</label>
+                            <label className="block font-medium text-black dark:text-white mb-1">Username</label>
                             <input
                                 type="text"
                                 className={getInputClass("username")}
@@ -262,7 +262,7 @@ export default function RegisterMultiStepPage() {
 
                         {/* PHONE NUMBER */}
                         <div>
-                            <label className="block font-medium text-black mb-1">Phone number</label>
+                            <label className="block font-medium text-black dark:text-white mb-1">Phone number</label>
                             <input
                                 type="text"
                                 className={getInputClass("phoneNumber")}
@@ -277,7 +277,7 @@ export default function RegisterMultiStepPage() {
 
                         {/* DATE OF BIRTH */}
                         <div>
-                            <label className="block font-medium text-black mb-1">Date of birth</label>
+                            <label className="block font-medium text-black dark:text-white mb-1">Date of birth</label>
                             <p className="text-xs text-gray-500 mb-2">
                                 This will not be shown publicly. Confirm your own age.
                             </p>
@@ -353,7 +353,7 @@ export default function RegisterMultiStepPage() {
 
                 {step === 2 && (
                     <form onSubmit={handleSubmit} className="space-y-6">
-                        <h1 className="text-3xl font-bold text-black">Additional Details</h1>
+                        <h1 className="text-3xl font-bold text-black dark:text-white">Additional Details</h1>
 
                         {/* LOGIN PASSWORD */}
                         <div>
@@ -374,7 +374,7 @@ export default function RegisterMultiStepPage() {
 
                         {/* GENDER */}
                         <div>
-                            <label className="block text-sm font-medium text-black mb-1">Хүйс</label>
+                            <label className="block text-sm font-medium text-black dark:text-white mb-1">Хүйс</label>
                             <select
                                 className={getInputClass("gender")}
                                 value={gender}
@@ -391,7 +391,7 @@ export default function RegisterMultiStepPage() {
 
                         {/* LOCATION */}
                         <div>
-                            <label className="block text-sm font-medium text-black mb-1">
+                            <label className="block text-sm font-medium text-black dark:text-white mb-1">
                                 Байршил
                             </label>
                             <input
@@ -408,7 +408,7 @@ export default function RegisterMultiStepPage() {
 
                         {/* PROFILE PICTURE + LOCAL SIZE CHECK */}
                         <div>
-                            <label className="block text-sm font-medium text-black mb-1">
+                            <label className="block text-sm font-medium text-black dark:text-white mb-1">
                                 Профайл зураг
                             </label>
                             <input
@@ -429,7 +429,7 @@ export default function RegisterMultiStepPage() {
                             <button
                                 type="button"
                                 onClick={() => setStep(1)}
-                                className="flex-1 bg-gray-200 text-black py-3 rounded-md font-semibold hover:bg-gray-300 transition"
+                                className="flex-1 bg-gray-200 dark:bg-gray-700 text-black dark:text-white py-3 rounded-md font-semibold hover:bg-gray-300 dark:hover:bg-gray-600 transition"
                             >
                                 Буцах
                             </button>

--- a/src/app/shop/[productId]/page.tsx
+++ b/src/app/shop/[productId]/page.tsx
@@ -35,7 +35,7 @@ export default function ProductDetailPage() {
   /* ── loading / error state ───────────────────────── */
   if (!product) {
     return (
-      <div className="min-h-screen bg-white text-black p-8">
+      <div className="min-h-screen bg-white dark:bg-dark text-black dark:text-white p-8">
         <p className="text-center text-red-500">
           {status || "Уншиж байна..."}
         </p>
@@ -47,7 +47,7 @@ export default function ProductDetailPage() {
 
   /* ── render ──────────────────────────────────────── */
   return (
-    <main className="min-h-screen bg-white text-black py-8 px-4">
+    <main className="min-h-screen bg-white dark:bg-dark text-black dark:text-white py-8 px-4">
       <div className="max-w-5xl mx-auto flex flex-col md:flex-row gap-10">
         {/* image */}
         <div className="w-full md:w-1/2 bg-[#16181C] rounded flex items-center justify-center overflow-hidden">

--- a/src/app/shop/cart/page.tsx
+++ b/src/app/shop/cart/page.tsx
@@ -13,14 +13,14 @@ export default function CartPage() {
 
     if (items.length === 0) {
         return (
-            <main className="min-h-screen flex items-center justify-center">
-                <p className="text-gray-600">Сагс хоосон байна.</p>
+            <main className="min-h-screen flex items-center justify-center bg-white dark:bg-dark text-black dark:text-white">
+                <p className="text-gray-600 dark:text-gray-300">Сагс хоосон байна.</p>
             </main>
         );
     }
 
     return (
-        <main className="min-h-screen px-4 py-8">
+        <main className="min-h-screen px-4 py-8 bg-white dark:bg-dark text-black dark:text-white">
             <div className="max-w-2xl mx-auto space-y-6">
                 <h1 className="text-3xl font-bold text-center">Таны сагс</h1>
                 <ul className="space-y-4">
@@ -28,7 +28,7 @@ export default function CartPage() {
                         <li key={item.product._id} className="flex justify-between items-center border-b pb-2">
                             <div>
                                 <p className="font-semibold">{item.product.name}</p>
-                                <p className="text-sm text-gray-500">Тоо: {item.quantity}</p>
+                                <p className="text-sm text-gray-500 dark:text-gray-400">Тоо: {item.quantity}</p>
                             </div>
                             <div className="flex items-center gap-4">
                                 <p>
@@ -47,7 +47,7 @@ export default function CartPage() {
                 </ul>
                 <p className="text-right font-bold">Нийт: {total.toLocaleString("mn-MN")}₮</p>
                 <div className="flex justify-between">
-                    <button onClick={clearCart} className="text-sm text-gray-600">
+                    <button onClick={clearCart} className="text-sm text-gray-600 dark:text-gray-300">
                         Сагсыг цэвэрлэх
                     </button>
                     <Link href="/shop/checkout" className="bg-[#1D9BF0] text-white px-4 py-2 rounded">

--- a/src/app/shop/checkout/page.tsx
+++ b/src/app/shop/checkout/page.tsx
@@ -19,14 +19,14 @@ export default function CheckoutPage() {
 
     if (items.length === 0) {
         return (
-            <main className="min-h-screen flex items-center justify-center">
-                <p className="text-gray-600">Сагс хоосон байна.</p>
+            <main className="min-h-screen flex items-center justify-center bg-white dark:bg-dark text-black dark:text-white">
+                <p className="text-gray-600 dark:text-gray-300">Сагс хоосон байна.</p>
             </main>
         );
     }
 
     return (
-        <main className="min-h-screen px-4 py-8">
+        <main className="min-h-screen px-4 py-8 bg-white dark:bg-dark text-black dark:text-white">
             <div className="max-w-xl mx-auto space-y-6">
                 <h1 className="text-3xl font-bold text-center mb-4">Төлбөр хийх</h1>
                 <ul className="space-y-2">
@@ -48,7 +48,7 @@ export default function CheckoutPage() {
                 <button onClick={handleCheckout} className="w-full bg-[#1D9BF0] text-white px-4 py-2 rounded">
                     Захиалах
                 </button>
-                <Link href="/shop/cart" className="block text-center text-sm text-gray-600 mt-2">
+                <Link href="/shop/cart" className="block text-center text-sm text-gray-600 dark:text-gray-300 mt-2">
                     Буцах
                 </Link>
             </div>

--- a/src/app/shop/page.tsx
+++ b/src/app/shop/page.tsx
@@ -30,7 +30,7 @@ export default function ShopPage() {
 
   /* ── render ──────────────────────────────────────── */
   return (
-    <main className="min-h-screen bg-white text-black px-4 py-8">
+    <main className="min-h-screen bg-white dark:bg-dark text-black dark:text-white px-4 py-8">
       <div className="max-w-4xl mx-auto">
         <h1 className="text-3xl font-bold mb-8 text-center tracking-wider uppercase">
           Дэлгүүр
@@ -46,13 +46,13 @@ export default function ShopPage() {
               <Link
                 key={p._id}
                 href={`/shop/${p._id}`}
-                className="group relative rounded-lg overflow-hidden border border-gray-200 bg-white
+                className="group relative rounded-lg overflow-hidden border border-gray-200 bg-white dark:bg-gray-800
                            hover:shadow-lg hover:shadow-[#1D9BF0]/30 hover:-translate-y-1 hover:scale-[1.01]
                            transition-transform duration-300 flex flex-col"
               >
                 {/* thumbnail */}
                 {p.imageUrl ? (
-                  <div className="relative w-full aspect-[3/4] overflow-hidden bg-white">
+                  <div className="relative w-full aspect-[3/4] overflow-hidden bg-white dark:bg-gray-700">
                     <img
                       src={`https://www.vone.mn/${p.imageUrl}`}
                       alt={p.name}
@@ -84,7 +84,7 @@ export default function ShopPage() {
                       </p>
                     </div>
                   ) : (
-                    <p className="mt-auto text-lg font-bold text-black">
+                    <p className="mt-auto text-lg font-bold text-black dark:text-white">
                       {finalPrice.toLocaleString("mn-MN")}₮
                     </p>
                   )}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,6 +1,7 @@
 // tailwind.config.js
 
 module.exports = {
+  darkMode: 'class',
   content: [
     './src/**/*.{js,ts,jsx,tsx}', // Adjust based on your project structure
     './public/**/*.html',


### PR DESCRIPTION
## Summary
- extend dark mode support to multiple components and pages
- tweak Header, Footer, BottomNav, and Modal styles for dark theme
- update shop, profile, book, and auth pages with dark classes
- refine FAQ section and subscription page backgrounds

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846bbba80988328a2886c168d7c6690