### PR TITLE
Improve dark mode visuals

### DIFF
--- a/src/app/components/BottomNav.tsx
+++ b/src/app/components/BottomNav.tsx
@@ -16,36 +16,36 @@ const BottomNav: React.FC = () => {
 
     return (
         <nav
-            className="fixed bottom-0 left-0 w-full bg-white dark:bg-black border-t border-gray-200 dark:border-black z-50 shadow-sm"
+            className="fixed bottom-0 left-0 w-full bg-white dark:bg-black border-t border-gray-200 dark:border-[#2F3336] z-50 shadow-sm"
         >
             <div className="flex justify-around items-center py-3 sm:py-4">
                 {/* HOME */}
                 <button
                     onClick={() => router.push("/")}
-                    className="flex flex-col items-center text-black dark:text-white hover:text-gray-600 dark:hover:text-white transition p-1"
+                    className="flex flex-col items-center text-black dark:text-white hover:text-gray-600 dark:hover:text-[#181818] transition p-1"
                 >
-                    <HomeIcon className="h-6 w-6 sm:h-7 sm:w-7" />
+                    <HomeIcon className="h-6 w-6 sm:h-7 sm:w-7 dark:text-white" />
                 </button>
 
                 {/* TIME */}
                 <button
                     onClick={() => router.push("/orders")}
-                    className="flex flex-col items-center text-black dark:text-white hover:text-gray-600 dark:hover:text-white transition p-1"
+                    className="flex flex-col items-center text-black dark:text-white hover:text-gray-600 dark:hover:text-[#181818] transition p-1"
                 >
-                    <ClockIcon className="h-6 w-6 sm:h-7 sm:w-7" />
+                    <ClockIcon className="h-6 w-6 sm:h-7 sm:w-7 dark:text-white" />
                 </button>
                 <button
                     onClick={() => router.push("/orders")}
-                    className="flex flex-col items-center text-black dark:text-white hover:text-gray-600 dark:hover:text-white transition p-1"
+                    className="flex flex-col items-center text-black dark:text-white hover:text-gray-600 dark:hover:text-[#181818] transition p-1"
                 >
-                    <ShoppingBagIcon className="h-6 w-6 sm:h-7 sm:w-7" />
+                    <ShoppingBagIcon className="h-6 w-6 sm:h-7 sm:w-7 dark:text-white" />
                 </button>
                 {/* PROFILE */}
                 <button
                     onClick={() => router.push("/profile")}
-                    className="flex flex-col items-center text-black dark:text-white hover:text-gray-600 dark:hover:text-white transition p-1"
+                    className="flex flex-col items-center text-black dark:text-white hover:text-gray-600 dark:hover:text-[#181818] transition p-1"
                 >
-                    <UserCircleIcon className="h-6 w-6 sm:h-7 sm:w-7" />
+                    <UserCircleIcon className="h-6 w-6 sm:h-7 sm:w-7 dark:text-white" />
                 </button>
             </div>
         </nav>

--- a/src/app/components/FAQSection.tsx
+++ b/src/app/components/FAQSection.tsx
@@ -18,7 +18,7 @@ const SingleFAQItem: React.FC<FAQItemProps> = ({
     return (
         <div
             onClick={onClick}
-            className="border-b border-gray-200 dark:border-black cursor-pointer py-4 hover:bg-gray-50 dark:hover:bg-black transition"
+            className="border-b border-gray-200 dark:border-[#2F3336] cursor-pointer py-4 hover:bg-gray-50 dark:hover:bg-black transition"
         >
             <div className="flex items-center justify-between">
                 <h3 className="font-semibold text-base md:text-lg text-gray-900 dark:text-white">

--- a/src/app/components/Header.tsx
+++ b/src/app/components/Header.tsx
@@ -31,7 +31,6 @@ export default function Header() {
                             alt="Лого"
                             className="h-8 w-auto object-contain transition-transform hover:scale-105"
                         />
-                        <span className="text-black dark:text-white font-bold text-lg">Vone</span>
                     </Link>
 
                     {/* Desktop Links */}

--- a/src/app/components/Timeline.tsx
+++ b/src/app/components/Timeline.tsx
@@ -31,12 +31,12 @@ const Timeline: React.FC<TimelineProps> = ({ posts = [] }) => {
                     >
                         {/* Icon container */}
                         <div className="flex-shrink-0 relative z-10">
-                            <div className="w-12 h-12 flex items-center justify-center bg-[#0055FF] text-white rounded-full shadow-lg">
+                            <div className="w-12 h-12 flex items-center justify-center bg-[#0055FF] text-white rounded-md shadow-lg">
                                 {post.imageUrl ? (
                                     <img
                                         src={post.imageUrl}
                                         alt={post.title}
-                                        className="w-full h-full object-cover rounded-full"
+                                        className="w-full h-full object-cover rounded-md"
                                     />
                                 ) : (
                                     post.title.charAt(0)

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -88,12 +88,12 @@ export default function RootLayout({
                                     <Link
                                         href="/"
                                         className="group flex items-center gap-2 p-4 pl-0 text-xl font-semibold
-                                   text-gray-700 transition-smooth focus:outline-none
-                                   focus:ring-2 focus:ring-[#1D9BF0]"
-                                    >
+                                   text-gray-700 dark:text-white transition-smooth focus:outline-none
+                                   dark:hover:text-[#181818] focus:ring-2 focus:ring-[#1D9BF0]"
+                                   >
                                         <svg
                                             xmlns="http://www.w3.org/2000/svg"
-                                            className="w-6 h-6 group-hover:text-[#1D9BF0]"
+                                            className="w-6 h-6 group-hover:text-[#1D9BF0] dark:text-white dark:group-hover:text-[#181818]"
                                             fill="none"
                                             viewBox="0 0 24 24"
                                             stroke="currentColor"
@@ -110,19 +110,19 @@ export default function RootLayout({
                                0h6"
                                             />
                                         </svg>
-                                        <span>Нүүр</span>
+                                        <span className="dark:text-white">Нүүр</span>
                                     </Link>
                                 </li>
                                 <li>
                                     <Link
                                         href="/book"
                                         className="group flex items-center gap-2 p-4 pl-0 text-xl font-semibold
-                                   text-gray-700 transition-smooth focus:outline-none
-                                   focus:ring-2 focus:ring-[#1D9BF0]"
-                                    >
+                                   text-gray-700 dark:text-white transition-smooth focus:outline-none
+                                   dark:hover:text-[#181818] focus:ring-2 focus:ring-[#1D9BF0]"
+                                   >
                                         <svg
                                             xmlns="http://www.w3.org/2000/svg"
-                                            className="w-6 h-6 group-hover:text-[#1D9BF0]"
+                                            className="w-6 h-6 group-hover:text-[#1D9BF0] dark:text-white dark:group-hover:text-[#181818]"
                                             fill="none"
                                             viewBox="0 0 24 24"
                                             stroke="currentColor"
@@ -142,19 +142,19 @@ export default function RootLayout({
                                0 00-6 2.292m0-14.25v14.25"
                                             />
                                         </svg>
-                                        <span>Ном</span>
+                                        <span className="dark:text-white">Ном</span>
                                     </Link>
                                 </li>
                                 <li>
                                     <Link
                                         href="/notifications"
                                         className="group flex items-center gap-2 p-4 pl-0 text-xl font-semibold
-                                   text-gray-700 transition-smooth  focus:outline-none
-                                   focus:ring-2 focus:ring-[#1D9BF0]"
-                                    >
+                                   text-gray-700 dark:text-white transition-smooth focus:outline-none
+                                   dark:hover:text-[#181818] focus:ring-2 focus:ring-[#1D9BF0]"
+                                   >
                                         <svg
                                             xmlns="http://www.w3.org/2000/svg"
-                                            className="w-6 h-6 group-hover:text-[#1D9BF0]"
+                                            className="w-6 h-6 group-hover:text-[#1D9BF0] dark:text-white dark:group-hover:text-[#181818]"
                                             fill="none"
                                             viewBox="0 0 24 24"
                                             stroke="currentColor"
@@ -171,19 +171,19 @@ export default function RootLayout({
                                16h6M7 8h6v4H7V8z"
                                             />
                                         </svg>
-                                        <span>Мэдээлэл</span>
+                                        <span className="dark:text-white">Мэдээлэл</span>
                                     </Link>
                                 </li>
                                 <li>
                                     <Link
                                         href="/shop"
                                         className="group flex items-center gap-2 p-4 pl-0 text-xl font-semibold
-                                   text-gray-700 transition-smooth focus:outline-none
-                                   focus:ring-2 focus:ring-[#1D9BF0]"
-                                    >
+                                   text-gray-700 dark:text-white transition-smooth focus:outline-none
+                                   dark:hover:text-[#181818] focus:ring-2 focus:ring-[#1D9BF0]"
+                                   >
                                         <svg
                                             xmlns="http://www.w3.org/2000/svg"
-                                            className="w-6 h-6 group-hover:text-[#1D9BF0]"
+                                            className="w-6 h-6 group-hover:text-[#1D9BF0] dark:text-white dark:group-hover:text-[#181818]"
                                             fill="none"
                                             viewBox="0 0 24 24"
                                             stroke="currentColor"
@@ -197,19 +197,19 @@ export default function RootLayout({
                                9z"
                                             />
                                         </svg>
-                                        <span>Дэлгүүр</span>
+                                        <span className="dark:text-white">Дэлгүүр</span>
                                     </Link>
                                 </li>
                                 <li>
                                     <Link
                                         href="/profile"
                                         className="group flex items-center gap-2 p-4 pl-0 text-xl font-semibold
-                                   text-gray-700 transition-smooth focus:outline-none
-                                   focus:ring-2 focus:ring-[#1D9BF0]"
-                                    >
+                                   text-gray-700 dark:text-white transition-smooth focus:outline-none
+                                   dark:hover:text-[#181818] focus:ring-2 focus:ring-[#1D9BF0]"
+                                   >
                                         <svg
                                             xmlns="http://www.w3.org/2000/svg"
-                                            className="w-6 h-6 group-hover:text-[#1D9BF0]"
+                                            className="w-6 h-6 group-hover:text-[#1D9BF0] dark:text-white dark:group-hover:text-[#181818]"
                                             fill="none"
                                             viewBox="0 0 24 24"
                                             stroke="currentColor"
@@ -224,21 +224,21 @@ export default function RootLayout({
                                7 0 00-7-7z"
                                             />
                                         </svg>
-                                        <span>Гишүүд</span>
+                                        <span className="dark:text-white">Гишүүд</span>
                                     </Link>
                                 </li>
                                 <li>
                                     <Link
                                         href="/settings"
                                         className="group flex items-center gap-2 p-4 pl-0 text-xl font-semibold
-                                   text-gray-700 transition-smooth focus:outline-none
-                                   focus:ring-2 focus:ring-[#1D9BF0]"
-                                    >
+                                   text-gray-700 dark:text-white transition-smooth focus:outline-none
+                                   dark:hover:text-[#181818] focus:ring-2 focus:ring-[#1D9BF0]"
+                                   >
                                         <svg
                                             xmlns="http://www.w3.org/2000/svg"
                                             viewBox="0 0 24 24"
                                             fill="currentColor"
-                                            className="w-6 h-6 group-hover:text-[#1D9BF0]"
+                                            className="w-6 h-6 group-hover:text-[#1D9BF0] dark:text-white dark:group-hover:text-[#181818]"
                                         >
                                             <path d="M3 4.5C3 3.12 4.12
                                   2 5.5 2h13C19.88 2
@@ -251,21 +251,21 @@ export default function RootLayout({
                                   .5-.22.5-.5v-15c0-.28-.22-.5-.5-.5h-13zM16
                                   10H8V8h8v2zm-8 2h8v2H8v-2z" />
                                         </svg>
-                                        <span>Таск</span>
+                                        <span className="dark:text-white">Таск</span>
                                     </Link>
                                 </li>
                                 <li>
                                     <Link
                                         href="/settings"
                                         className="group flex items-center gap-2 p-4 pl-0 text-xl font-semibold
-                                   text-gray-700 transition-smooth focus:outline-none
-                                   focus:ring-2 focus:ring-[#1D9BF0]"
-                                    >
+                                   text-gray-700 dark:text-white transition-smooth focus:outline-none
+                                   dark:hover:text-[#181818] focus:ring-2 focus:ring-[#1D9BF0]"
+                                   >
                                         <svg
                                             xmlns="http://www.w3.org/2000/svg"
                                             viewBox="0 0 24 24"
                                             fill="currentColor"
-                                            className="w-6 h-6 group-hover:text-[#1D9BF0]"
+                                            className="w-6 h-6 group-hover:text-[#1D9BF0] dark:text-white dark:group-hover:text-[#181818]"
                                         >
                                             <path d="M19.5 6H17V4.5C17
                                   3.12 15.88 2 14.5
@@ -283,7 +283,7 @@ export default function RootLayout({
                                   0-2-.9-2-2V8.5c0-.28.23-.5.5-.5h15c.28
                                   0 .5.22.5.5v3.51z"/>
                                         </svg>
-                                        <span>Ажил</span>
+                                        <span className="dark:text-white">Ажил</span>
                                     </Link>
                                 </li>
                             </ul>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -284,7 +284,7 @@ export default function HomePage() {
                                     initial={{ opacity: 0, y: 20 }}
                                     animate={{ opacity: 1, y: 0 }}
                                     transition={{ delay: idx * 0.02 }}
-                                    className="bg-white dark:bg-black p-6 grid gap-4 border-b border-gray-200 dark:border-black"
+                                    className="bg-white dark:bg-black p-6 grid gap-4 border-b border-gray-200 dark:border-[#2F3336]"
                                 >
                                     <div className="grid grid-cols-[auto,1fr] gap-5">
                                         {/* Profile Picture with Skeleton Fallback */}
@@ -293,13 +293,13 @@ export default function HomePage() {
                                                 <img
                                                     src={`${BASE_URL}${postUser.profilePicture}`}
                                                     alt="Avatar"
-                                                    className="w-12 h-12 object-cover rounded-full"
+                                                    className="w-12 h-12 object-cover rounded-md"
                                                     onError={(e) => {
                                                         e.currentTarget.style.display = "none";
                                                     }}
                                                 />
                                             ) : (
-                                                <div className="w-12 h-12 rounded-full bg-gray-300 animate-pulse" />
+                                                <div className="w-12 h-12 rounded-md bg-gray-300 animate-pulse" />
                                             )}
                                         </div>
 


### PR DESCRIPTION
## Summary
- adjust nav styles for better dark mode support
- remove text from header logo
- change border colors for dark mode
- tweak bottom nav and timeline avatars

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846ce9ed3908328b3c27a2f2922f125