### PR TITLE
Revamp header and navigation styles

### DIFF
--- a/src/app/components/BottomNav.tsx
+++ b/src/app/components/BottomNav.tsx
@@ -22,30 +22,30 @@ const BottomNav: React.FC = () => {
                 {/* HOME */}
                 <button
                     onClick={() => router.push("/")}
-                    className="flex flex-col items-center text-black dark:text-white hover:text-gray-600 dark:hover:text-[#181818] transition p-1"
+                    className="flex flex-col items-center text-black dark:text-white hover:text-[#1D9BF0] dark:hover:text-[#1D9BF0] transition p-1"
                 >
-                    <HomeIcon className="h-6 w-6 sm:h-7 sm:w-7 dark:text-white" />
+                    <HomeIcon className="h-6 w-6 sm:h-7 sm:w-7 dark:text-white group-hover:text-[#1D9BF0] dark:group-hover:text-[#1D9BF0]" />
                 </button>
 
                 {/* TIME */}
                 <button
                     onClick={() => router.push("/orders")}
-                    className="flex flex-col items-center text-black dark:text-white hover:text-gray-600 dark:hover:text-[#181818] transition p-1"
+                    className="flex flex-col items-center text-black dark:text-white hover:text-[#1D9BF0] dark:hover:text-[#1D9BF0] transition p-1"
                 >
-                    <ClockIcon className="h-6 w-6 sm:h-7 sm:w-7 dark:text-white" />
+                    <ClockIcon className="h-6 w-6 sm:h-7 sm:w-7 dark:text-white group-hover:text-[#1D9BF0] dark:group-hover:text-[#1D9BF0]" />
                 </button>
                 <button
                     onClick={() => router.push("/orders")}
-                    className="flex flex-col items-center text-black dark:text-white hover:text-gray-600 dark:hover:text-[#181818] transition p-1"
+                    className="flex flex-col items-center text-black dark:text-white hover:text-[#1D9BF0] dark:hover:text-[#1D9BF0] transition p-1"
                 >
-                    <ShoppingBagIcon className="h-6 w-6 sm:h-7 sm:w-7 dark:text-white" />
+                    <ShoppingBagIcon className="h-6 w-6 sm:h-7 sm:w-7 dark:text-white group-hover:text-[#1D9BF0] dark:group-hover:text-[#1D9BF0]" />
                 </button>
                 {/* PROFILE */}
                 <button
                     onClick={() => router.push("/profile")}
-                    className="flex flex-col items-center text-black dark:text-white hover:text-gray-600 dark:hover:text-[#181818] transition p-1"
+                    className="flex flex-col items-center text-black dark:text-white hover:text-[#1D9BF0] dark:hover:text-[#1D9BF0] transition p-1"
                 >
-                    <UserCircleIcon className="h-6 w-6 sm:h-7 sm:w-7 dark:text-white" />
+                    <UserCircleIcon className="h-6 w-6 sm:h-7 sm:w-7 dark:text-white group-hover:text-[#1D9BF0] dark:group-hover:text-[#1D9BF0]" />
                 </button>
             </div>
         </nav>

--- a/src/app/components/Header.tsx
+++ b/src/app/components/Header.tsx
@@ -1,8 +1,6 @@
 "use client";
 import React, { useState } from "react";
 import Link from "next/link";
-import Image from "next/image";
-import logo from "@/app/img/logo.svg";
 import { useAuth } from "../context/AuthContext";
 import ThemeToggle from "./ThemeToggle";
 
@@ -24,14 +22,7 @@ export default function Header() {
             <div className="fixed top-0 left-0 w-full z-[999] bg-white dark:bg-dark md:bg-white/80 dark:md:bg-dark/80 backdrop-blur-md">
                 {/* NAV BAR */}
                 <nav className="max-w-7xl mx-auto px-6 py-4 flex items-center justify-between">
-                    {/* Logo */}
-                    <Link href="/" className="flex items-center gap-2">
-                        <Image
-                            src={logo}
-                            alt="Лого"
-                            className="h-8 w-auto object-contain transition-transform hover:scale-105"
-                        />
-                    </Link>
+
 
                     {/* Desktop Links */}
                     <div className="hidden md:flex items-center space-x-8 font-medium">
@@ -39,7 +30,7 @@ export default function Header() {
                         {loggedIn ? (
                             <button
                                 onClick={logout}
-                                className="relative group text-gray-700 dark:text-white hover:text-[#1D9BF0]"
+                                className="relative group text-gray-700 dark:text-white hover:text-[#1D9BF0] dark:hover:text-[#1D9BF0]"
                             >
                                 Гарах
                                 <span className="absolute left-0 bottom-0 w-full h-0.5 bg-[#1D9BF0] scale-x-0 group-hover:scale-x-100 transition-transform origin-left" />
@@ -48,14 +39,14 @@ export default function Header() {
                             <>
                                 <Link
                                     href="/login"
-                                    className="relative group text-gray-700 dark:text-white hover:text-[#1D9BF0]"
+                                    className="relative group text-gray-700 dark:text-white hover:text-[#1D9BF0] dark:hover:text-[#1D9BF0]"
                                 >
                                     Нэвтрэх
                                     <span className="absolute left-0 bottom-0 w-full h-0.5 bg-[#1D9BF0] scale-x-0 group-hover:scale-x-100 transition-transform origin-left" />
                                 </Link>
                                 <Link
                                     href="/register"
-                                    className="relative group text-gray-700 dark:text-white hover:text-[#1D9BF0]"
+                                    className="relative group text-gray-700 dark:text-white hover:text-[#1D9BF0] dark:hover:text-[#1D9BF0]"
                                 >
                                     Бүртгүүлэх
                                     <span className="absolute left-0 bottom-0 w-full h-0.5 bg-[#1D9BF0] scale-x-0 group-hover:scale-x-100 transition-transform origin-left" />
@@ -94,14 +85,7 @@ export default function Header() {
                     {/* This inner container stops the click event from bubbling up */}
                     <div onClick={(e) => e.stopPropagation()}>
                         {/* Drawer Header */}
-                        <div className="flex items-center justify-between p-4">
-                            <Link href="/" onClick={() => setIsMenuOpen(false)}>
-                                <Image
-                                    src={logo}
-                                    alt="Лого"
-                                    className="h-8 w-auto object-contain"
-                                />
-                            </Link>
+                        <div className="flex items-center justify-end p-4">
                             <button
                                 className="text-gray-500 dark:text-white text-3xl focus:outline-none hover:text-gray-700 dark:hover:text-white"
                                 onClick={() => setIsMenuOpen(false)}
@@ -124,7 +108,7 @@ export default function Header() {
                                                 logout();
                                                 setIsMenuOpen(false);
                                             }}
-                                            className="block text-left w-full text-xl font-medium text-gray-800 dark:text-white hover:text-[#1D9BF0]"
+                                            className="block text-left w-full text-xl font-medium text-gray-800 dark:text-white hover:text-[#1D9BF0] dark:hover:text-[#1D9BF0]"
                                         >
                                             Гарах
                                         </button>
@@ -135,7 +119,7 @@ export default function Header() {
                                             <Link
                                                 href="/login"
                                                 onClick={() => setIsMenuOpen(false)}
-                                                className="block text-xl font-medium text-gray-800 dark:text-white hover:text-[#1D9BF0]"
+                                                className="block text-xl font-medium text-gray-800 dark:text-white hover:text-[#1D9BF0] dark:hover:text-[#1D9BF0]"
                                             >
                                                 Нэвтрэх
                                             </Link>
@@ -144,7 +128,7 @@ export default function Header() {
                                             <Link
                                                 href="/register"
                                                 onClick={() => setIsMenuOpen(false)}
-                                                className="block text-xl font-medium text-gray-800 dark:text-white hover:text-[#1D9BF0]"
+                                                className="block text-xl font-medium text-gray-800 dark:text-white hover:text-[#1D9BF0] dark:hover:text-[#1D9BF0]"
                                             >
                                                 Бүртгүүлэх
                                             </Link>
@@ -154,13 +138,13 @@ export default function Header() {
                             </ul>
 
                             {/* Additional Nav Items */}
-                            <div className="mt-10 border-t pt-6">
+                            <div className="mt-10 border-t border-gray-200 dark:border-gray-700 pt-6">
                                 <ul className="space-y-4 text-lg font-semibold text-gray-700 dark:text-white">
                                     <li>
                                         <Link
                                             href="/"
                                             onClick={() => setIsMenuOpen(false)}
-                                            className="flex items-center gap-2 hover:text-[#1D9BF0]"
+                                            className="flex items-center gap-2 hover:text-[#1D9BF0] dark:hover:text-[#1D9BF0]"
                                         >
                                             <svg
                                                 xmlns="http://www.w3.org/2000/svg"
@@ -183,7 +167,7 @@ export default function Header() {
                                         <Link
                                             href="/book"
                                             onClick={() => setIsMenuOpen(false)}
-                                            className="flex items-center gap-2 hover:text-[#1D9BF0]"
+                                            className="flex items-center gap-2 hover:text-[#1D9BF0] dark:hover:text-[#1D9BF0]"
                                         >
                                             <svg
                                                 xmlns="http://www.w3.org/2000/svg"
@@ -206,7 +190,7 @@ export default function Header() {
                                         <Link
                                             href="/notifications"
                                             onClick={() => setIsMenuOpen(false)}
-                                            className="flex items-center gap-2 hover:text-[#1D9BF0]"
+                                            className="flex items-center gap-2 hover:text-[#1D9BF0] dark:hover:text-[#1D9BF0]"
                                         >
                                             <svg
                                                 xmlns="http://www.w3.org/2000/svg"
@@ -229,7 +213,7 @@ export default function Header() {
                                         <Link
                                             href="/shop"
                                             onClick={() => setIsMenuOpen(false)}
-                                            className="flex items-center gap-2 hover:text-[#1D9BF0]"
+                                            className="flex items-center gap-2 hover:text-[#1D9BF0] dark:hover:text-[#1D9BF0]"
                                         >
                                             <svg
                                                 xmlns="http://www.w3.org/2000/svg"
@@ -252,7 +236,7 @@ export default function Header() {
                                         <Link
                                             href="/users"
                                             onClick={() => setIsMenuOpen(false)}
-                                            className="flex items-center gap-2 hover:text-[#1D9BF0]"
+                                            className="flex items-center gap-2 hover:text-[#1D9BF0] dark:hover:text-[#1D9BF0]"
                                         >
                                             <svg
                                                 xmlns="http://www.w3.org/2000/svg"
@@ -275,7 +259,7 @@ export default function Header() {
                                         <Link
                                             href="/settings"
                                             onClick={() => setIsMenuOpen(false)}
-                                            className="flex items-center gap-2 hover:text-[#1D9BF0]"
+                                            className="flex items-center gap-2 hover:text-[#1D9BF0] dark:hover:text-[#1D9BF0]"
                                         >
                                             <svg
                                                 xmlns="http://www.w3.org/2000/svg"
@@ -292,7 +276,7 @@ export default function Header() {
                                         <Link
                                             href="/settings"
                                             onClick={() => setIsMenuOpen(false)}
-                                            className="flex items-center gap-2 hover:text-[#1D9BF0]"
+                                            className="flex items-center gap-2 hover:text-[#1D9BF0] dark:hover:text-[#1D9BF0]"
                                         >
                                             <svg
                                                 xmlns="http://www.w3.org/2000/svg"

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -81,7 +81,7 @@ export default function RootLayout({
                 {/* Үндсэн Layout */}
                 <main className="flex-grow flex flex-col md:flex-row gap-0 pt-16">
                     {/* Зүүн талын Sidebar */}
-                    <aside className="hidden md:block w-full md:w-1/4 border-r border-gray-200 sticky top-16 h-[calc(100vh-80px)] overflow-y-auto fade-in-up">
+                    <aside className="hidden md:block w-full md:w-1/4 border-r border-gray-200 dark:border-gray-700 sticky top-16 h-[calc(100vh-80px)] overflow-y-auto fade-in-up">
                         <nav>
                             <ul className="space-y-1">
                                 <li>
@@ -89,11 +89,11 @@ export default function RootLayout({
                                         href="/"
                                         className="group flex items-center gap-2 p-4 pl-0 text-xl font-semibold
                                    text-gray-700 dark:text-white transition-smooth focus:outline-none
-                                   dark:hover:text-[#181818] focus:ring-2 focus:ring-[#1D9BF0]"
+                                   hover:text-[#1D9BF0] dark:hover:text-[#1D9BF0] focus:ring-2 focus:ring-[#1D9BF0]"
                                    >
                                         <svg
                                             xmlns="http://www.w3.org/2000/svg"
-                                            className="w-6 h-6 group-hover:text-[#1D9BF0] dark:text-white dark:group-hover:text-[#181818]"
+                                            className="w-6 h-6 group-hover:text-[#1D9BF0] dark:text-white dark:group-hover:text-[#1D9BF0]"
                                             fill="none"
                                             viewBox="0 0 24 24"
                                             stroke="currentColor"
@@ -118,11 +118,11 @@ export default function RootLayout({
                                         href="/book"
                                         className="group flex items-center gap-2 p-4 pl-0 text-xl font-semibold
                                    text-gray-700 dark:text-white transition-smooth focus:outline-none
-                                   dark:hover:text-[#181818] focus:ring-2 focus:ring-[#1D9BF0]"
+                                   hover:text-[#1D9BF0] dark:hover:text-[#1D9BF0] focus:ring-2 focus:ring-[#1D9BF0]"
                                    >
                                         <svg
                                             xmlns="http://www.w3.org/2000/svg"
-                                            className="w-6 h-6 group-hover:text-[#1D9BF0] dark:text-white dark:group-hover:text-[#181818]"
+                                            className="w-6 h-6 group-hover:text-[#1D9BF0] dark:text-white dark:group-hover:text-[#1D9BF0]"
                                             fill="none"
                                             viewBox="0 0 24 24"
                                             stroke="currentColor"
@@ -150,11 +150,11 @@ export default function RootLayout({
                                         href="/notifications"
                                         className="group flex items-center gap-2 p-4 pl-0 text-xl font-semibold
                                    text-gray-700 dark:text-white transition-smooth focus:outline-none
-                                   dark:hover:text-[#181818] focus:ring-2 focus:ring-[#1D9BF0]"
+                                   hover:text-[#1D9BF0] dark:hover:text-[#1D9BF0] focus:ring-2 focus:ring-[#1D9BF0]"
                                    >
                                         <svg
                                             xmlns="http://www.w3.org/2000/svg"
-                                            className="w-6 h-6 group-hover:text-[#1D9BF0] dark:text-white dark:group-hover:text-[#181818]"
+                                            className="w-6 h-6 group-hover:text-[#1D9BF0] dark:text-white dark:group-hover:text-[#1D9BF0]"
                                             fill="none"
                                             viewBox="0 0 24 24"
                                             stroke="currentColor"
@@ -179,11 +179,11 @@ export default function RootLayout({
                                         href="/shop"
                                         className="group flex items-center gap-2 p-4 pl-0 text-xl font-semibold
                                    text-gray-700 dark:text-white transition-smooth focus:outline-none
-                                   dark:hover:text-[#181818] focus:ring-2 focus:ring-[#1D9BF0]"
+                                   hover:text-[#1D9BF0] dark:hover:text-[#1D9BF0] focus:ring-2 focus:ring-[#1D9BF0]"
                                    >
                                         <svg
                                             xmlns="http://www.w3.org/2000/svg"
-                                            className="w-6 h-6 group-hover:text-[#1D9BF0] dark:text-white dark:group-hover:text-[#181818]"
+                                            className="w-6 h-6 group-hover:text-[#1D9BF0] dark:text-white dark:group-hover:text-[#1D9BF0]"
                                             fill="none"
                                             viewBox="0 0 24 24"
                                             stroke="currentColor"
@@ -205,11 +205,11 @@ export default function RootLayout({
                                         href="/users"
                                         className="group flex items-center gap-2 p-4 pl-0 text-xl font-semibold
                                    text-gray-700 dark:text-white transition-smooth focus:outline-none
-                                   dark:hover:text-[#181818] focus:ring-2 focus:ring-[#1D9BF0]"
+                                   hover:text-[#1D9BF0] dark:hover:text-[#1D9BF0] focus:ring-2 focus:ring-[#1D9BF0]"
                                    >
                                         <svg
                                             xmlns="http://www.w3.org/2000/svg"
-                                            className="w-6 h-6 group-hover:text-[#1D9BF0] dark:text-white dark:group-hover:text-[#181818]"
+                                            className="w-6 h-6 group-hover:text-[#1D9BF0] dark:text-white dark:group-hover:text-[#1D9BF0]"
                                             fill="none"
                                             viewBox="0 0 24 24"
                                             stroke="currentColor"
@@ -232,13 +232,13 @@ export default function RootLayout({
                                         href="/settings"
                                         className="group flex items-center gap-2 p-4 pl-0 text-xl font-semibold
                                    text-gray-700 dark:text-white transition-smooth focus:outline-none
-                                   dark:hover:text-[#181818] focus:ring-2 focus:ring-[#1D9BF0]"
+                                   hover:text-[#1D9BF0] dark:hover:text-[#1D9BF0] focus:ring-2 focus:ring-[#1D9BF0]"
                                    >
                                         <svg
                                             xmlns="http://www.w3.org/2000/svg"
                                             viewBox="0 0 24 24"
                                             fill="currentColor"
-                                            className="w-6 h-6 group-hover:text-[#1D9BF0] dark:text-white dark:group-hover:text-[#181818]"
+                                            className="w-6 h-6 group-hover:text-[#1D9BF0] dark:text-white dark:group-hover:text-[#1D9BF0]"
                                         >
                                             <path d="M3 4.5C3 3.12 4.12
                                   2 5.5 2h13C19.88 2
@@ -259,13 +259,13 @@ export default function RootLayout({
                                         href="/settings"
                                         className="group flex items-center gap-2 p-4 pl-0 text-xl font-semibold
                                    text-gray-700 dark:text-white transition-smooth focus:outline-none
-                                   dark:hover:text-[#181818] focus:ring-2 focus:ring-[#1D9BF0]"
+                                   hover:text-[#1D9BF0] dark:hover:text-[#1D9BF0] focus:ring-2 focus:ring-[#1D9BF0]"
                                    >
                                         <svg
                                             xmlns="http://www.w3.org/2000/svg"
                                             viewBox="0 0 24 24"
                                             fill="currentColor"
-                                            className="w-6 h-6 group-hover:text-[#1D9BF0] dark:text-white dark:group-hover:text-[#181818]"
+                                            className="w-6 h-6 group-hover:text-[#1D9BF0] dark:text-white dark:group-hover:text-[#1D9BF0]"
                                         >
                                             <path d="M19.5 6H17V4.5C17
                                   3.12 15.88 2 14.5
@@ -291,7 +291,7 @@ export default function RootLayout({
                     </aside>
 
                     {/* Үндсэн контент */}
-                    <div className="w-full md:w-1/2 md:border-r md:border-gray-200">
+                    <div className="w-full md:w-1/2 md:border-r md:border-gray-200 dark:md:border-gray-700">
                         <div className="space-y-6">{children}</div>
                     </div>
 


### PR DESCRIPTION
## Summary
- remove logo from header layout
- style nav links to stay blue on hover in both themes
- tweak mobile drawer border color
- adjust sidebar and bottom navigation hover states for dark mode

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684802c0fbb083289f7302aa64a86766