### PR TITLE
Improve layout with header slider and trends

### DIFF
--- a/src/app/components/Header.tsx
+++ b/src/app/components/Header.tsx
@@ -21,12 +21,9 @@ export default function Header() {
 
             <div className="fixed top-0 left-0 w-full z-[999] bg-white dark:bg-dark md:bg-white/80 dark:md:bg-dark/80 backdrop-blur-md">
                 {/* NAV BAR */}
-                <nav className="max-w-7xl mx-auto px-6 py-4 flex items-center justify-between">
-
-
-                    {/* Desktop Links */}
-                    <div className="hidden md:flex items-center space-x-8 font-medium">
-                        <ThemeToggle />
+                <nav className="max-w-7xl mx-auto px-6 py-4 flex items-center">
+                    <ThemeToggle />
+                    <div className="ml-auto hidden md:flex items-center space-x-8 font-medium">
                         {loggedIn ? (
                             <button
                                 onClick={logout}

--- a/src/app/components/HeaderSlider.tsx
+++ b/src/app/components/HeaderSlider.tsx
@@ -1,0 +1,45 @@
+"use client";
+import React from "react";
+import Slider from "react-slick";
+import Image from "next/image";
+import "slick-carousel/slick/slick.css";
+import "slick-carousel/slick/slick-theme.css";
+
+const slides = [
+  { src: "/android-chrome-512x512.png", alt: "Slide 1" },
+  { src: "/vercel.svg", alt: "Slide 2" },
+  { src: "/next.svg", alt: "Slide 3" },
+];
+
+const HeaderSlider: React.FC = () => {
+  const settings = {
+    dots: true,
+    arrows: false,
+    infinite: true,
+    autoplay: true,
+    speed: 500,
+  } as const;
+
+  return (
+    <div className="mb-4">
+      <Slider {...settings}>
+        {slides.map((s, i) => (
+          <div
+            key={i}
+            className="h-40 flex items-center justify-center bg-gray-100 dark:bg-[#111]"
+          >
+            <Image
+              src={s.src}
+              alt={s.alt}
+              width={150}
+              height={150}
+              className="object-contain"
+            />
+          </div>
+        ))}
+      </Slider>
+    </div>
+  );
+};
+
+export default HeaderSlider;

--- a/src/app/components/TrendingHashtags.tsx
+++ b/src/app/components/TrendingHashtags.tsx
@@ -1,0 +1,61 @@
+"use client";
+import React, { useEffect, useState } from "react";
+import axios from "axios";
+import { FiCamera } from "react-icons/fi";
+
+interface Hashtag {
+  tag: string;
+  count: number;
+}
+
+const BASE_URL = "https://www.vone.mn";
+
+const TrendingHashtags: React.FC = () => {
+  const [tags, setTags] = useState<Hashtag[]>([]);
+
+  useEffect(() => {
+    const fetchTrending = async () => {
+      try {
+        const res = await axios.get(`${BASE_URL}/api/posts`);
+        const hashtagCount: Record<string, number> = {};
+        res.data.forEach((post: any) => {
+          const hashtags = post.content.match(/#\w+/g);
+          if (hashtags) {
+            hashtags.forEach((tag: string) => {
+              hashtagCount[tag] = (hashtagCount[tag] || 0) + 1;
+            });
+          }
+        });
+        const trending = Object.entries(hashtagCount)
+          .map(([tag, count]) => ({ tag, count }))
+          .sort((a, b) => (b.count as number) - (a.count as number))
+          .slice(0, 5);
+        setTags(trending);
+      } catch (err) {
+        console.error(err);
+      }
+    };
+    fetchTrending();
+  }, []);
+
+  return (
+    <div className="p-4 transition-shadow duration-200 hover:shadow-md">
+      <h2 className="flex items-center font-semibold mb-3">
+        <FiCamera className="w-5 h-5 mr-2 text-[#1D9BF0]" />
+        Trending Hashtags
+      </h2>
+      <div className="flex flex-wrap gap-2">
+        {tags.map((t) => (
+          <span
+            key={t.tag}
+            className="px-3 py-1 text-xs bg-gray-200 dark:bg-black rounded-full"
+          >
+            {t.tag} ({t.count})
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default TrendingHashtags;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import { AuthProvider } from "./context/AuthContext";
 import { CartProvider } from "./context/CartContext";
 import { ThemeProvider } from "./context/ThemeContext";
 import Header from "./components/Header";
+import TrendingHashtags from "./components/TrendingHashtags";
 import type { Metadata } from "next";
 import Link from "next/link";
 
@@ -347,47 +348,7 @@ export default function RootLayout({
                                 </ul>
                             </div>
 
-                            {/* Зөвлөмж болгож буй хэрэглэгчид */}
-                            <div className="p-4 transition-shadow duration-200 hover:shadow-md">
-                                <h2 className="flex items-center font-semibold mb-3">
-                                    <svg
-                                        xmlns="http://www.w3.org/2000/svg"
-                                        className="w-5 h-5 mr-2 text-[#1D9BF0]"
-                                        fill="none"
-                                        viewBox="0 0 24 24"
-                                        stroke="currentColor"
-                                    >
-                                        <path
-                                            strokeLinecap="round"
-                                            strokeLinejoin="round"
-                                            strokeWidth="2"
-                                            d="M18 9v3m0
-                             0v3m0-3h3m-3
-                             0h-3m-2-5a4 4 0
-                             11-8 0 4 4 0
-                             018 0zM3 20a6
-                             6 0 0112 0v1H3v-1z"
-                                        />
-                                    </svg>
-                                    Зөвлөмж болгож буй хэрэглэгчид
-                                </h2>
-                                <div className="space-y-4">
-                                    <div className="flex items-center space-x-3">
-                                        <img
-                                            src="/placeholder-user.jpg"
-                                            alt="User avatar"
-                                            className="w-10 h-10 rounded-full"
-                                        />
-                                        <div className="flex-1">
-                                            <p className="font-semibold">Хэрэглэгч Нэг</p>
-                                            <p className="text-gray-500 text-sm">@userone</p>
-                                        </div>
-                                        <button className="bg-[#1D9BF0] text-white px-4 py-1 rounded-full hover:scale-105 transition-transform duration-200 focus:outline-none focus:ring-2 focus:ring-[#1D9BF0]">
-                                            Дагах
-                                        </button>
-                                    </div>
-                                </div>
-                            </div>
+                            <TrendingHashtags />
                         </div>
                     </aside>
                 </main>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,6 +6,7 @@ import { useAuth } from "./context/AuthContext";
 import { FaHeart, FaComment, FaShare } from "react-icons/fa";
 import { FiCamera } from "react-icons/fi";
 import { motion } from "framer-motion";
+import HeaderSlider from "./components/HeaderSlider";
 
 interface UserData {
     _id: string;
@@ -192,6 +193,7 @@ export default function HomePage() {
 
     return (
         <div className="min-h-screen bg-gray-100 dark:bg-black text-gray-900 dark:text-white">
+            <HeaderSlider />
             {/* Outer Grid Layout */}
             <div
                 className="mx-auto max-w-5xl w-full grid"

--- a/src/app/shop/page.tsx
+++ b/src/app/shop/page.tsx
@@ -52,7 +52,7 @@ export default function ShopPage() {
               >
                 {/* thumbnail */}
                 {p.imageUrl ? (
-                  <div className="relative w-full aspect-[3/4] overflow-hidden bg-white dark:bg-black">
+                  <div className="relative w-full aspect-square overflow-hidden bg-white dark:bg-black">
                     <img
                       src={`https://www.vone.mn/${p.imageUrl}`}
                       alt={p.name}
@@ -60,7 +60,7 @@ export default function ShopPage() {
                     />
                   </div>
                 ) : (
-                  <div className="w-full aspect-[3/4] bg-[#222] flex items-center justify-center text-gray-500">
+                  <div className="w-full aspect-square bg-[#222] flex items-center justify-center text-gray-500">
                     No Image
                   </div>
                 )}

--- a/src/app/users/page.tsx
+++ b/src/app/users/page.tsx
@@ -47,7 +47,7 @@ export default function UsersPage() {
                     <Link
                         key={user._id}
                         href={`/profile/${user._id}`}
-                        className="bg-white dark:bg-black border border-gray-200 dark:border-gray-800 rounded-lg p-4 flex flex-col items-center shadow-sm hover:shadow-md transition-shadow"
+                        className="bg-white dark:bg-black border border-gray-200 dark:border-gray-800 rounded-lg p-4 flex flex-col items-center shadow-sm hover:shadow-md hover:-translate-y-1 hover:scale-105 transition-transform"
                     >
                         {user.profilePicture ? (
                             <img


### PR DESCRIPTION
## Summary
- add header slider component
- add trending hashtags component
- move logout button to the right side
- display trending hashtags in sidebar
- make shop thumbnails square and polish user cards
- insert header slider on the home page

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68480b14e2d08328a129c885b16e89ba