### PR TITLE
Add type declaration for react-slick

### DIFF
--- a/types/react-slick.d.ts
+++ b/types/react-slick.d.ts
@@ -1,0 +1,1 @@
+declare module 'react-slick';


### PR DESCRIPTION
## Summary
- declare `react-slick` module in a new `types` folder

## Testing
- `npm install --save-dev @types/react-slick` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68480f022dc08328841abea0e6695137