### PR TITLE
Add user info in recommended feed and update subscription details

### DIFF
--- a/server/routes/post.js
+++ b/server/routes/post.js
@@ -45,6 +45,20 @@ router.get("/", async (req, res) => {
                 { $addFields: { likesCount: { $size: "$likes" } } },
                 { $sort: { likesCount: -1, createdAt: -1 } },
             ]);
+
+            await Post.populate(posts, {
+                path: "user",
+                select: "username profilePicture",
+            });
+            await Post.populate(posts, {
+                path: "comments.user",
+                select: "username profilePicture",
+            });
+            await Post.populate(posts, {
+                path: "comments.replies.user",
+                select: "username profilePicture",
+            });
+
             return res.json(posts);
         } else {
             // **IMPORTANT**: Populate both username and profilePicture.

--- a/src/app/components/SubscriptionPage.tsx
+++ b/src/app/components/SubscriptionPage.tsx
@@ -98,7 +98,14 @@ export default function SubscriptionPage() {
             <h1 className="text-2xl font-bold mb-4 text-center">
                 Сарын Гишүүнчлэл
             </h1>
-            <p className="mb-4 text-center text-gray-400">Төлбөр: 1,000₮ / сард</p>
+            <p className="mb-4 text-center text-gray-400">
+                Сарын төлбөр: эхний 10 гишүүнд 10,000₮, дараагийн 20 гишүүнд
+                20,000₮
+            </p>
+            <div className="mb-6 text-center space-y-1 text-sm text-gray-300">
+                <p>Golomt Bank: <strong>3005127815</strong></p>
+                <p>Khan Bank: <strong>5926153085</strong></p>
+            </div>
             {message && (
                 <div className="mb-3 p-2 bg-blue-900 text-blue-300 rounded text-center">
                     {message}

--- a/src/app/components/TrendingTopics.tsx
+++ b/src/app/components/TrendingTopics.tsx
@@ -1,0 +1,61 @@
+"use client";
+import React, { useEffect, useState } from "react";
+import axios from "axios";
+import { FiTrendingUp } from "react-icons/fi";
+
+interface Post {
+  _id: string;
+  content: string;
+  likes?: string[];
+  comments?: { _id: string }[];
+  shares?: number;
+}
+
+interface TrendingItem {
+  id: string;
+  text: string;
+  score: number;
+}
+
+const BASE_URL = "https://www.vone.mn";
+
+const TrendingTopics: React.FC = () => {
+  const [topics, setTopics] = useState<TrendingItem[]>([]);
+
+  useEffect(() => {
+    const fetchTrending = async () => {
+      try {
+        const res = await axios.get(`${BASE_URL}/api/posts`);
+        const items: TrendingItem[] = res.data.map((p: Post) => {
+          const score =
+            (p.likes?.length || 0) +
+            (p.comments?.length || 0) +
+            (p.shares || 0);
+          const text = p.content.length > 80 ? `${p.content.slice(0, 77)}...` : p.content;
+          return { id: p._id, text, score };
+        });
+        items.sort((a, b) => b.score - a.score);
+        setTopics(items.slice(0, 5));
+      } catch (err) {
+        console.error(err);
+      }
+    };
+    fetchTrending();
+  }, []);
+
+  return (
+    <div className="p-4 transition-shadow duration-200 hover:shadow-md">
+      <h2 className="flex items-center font-semibold mb-3">
+        <FiTrendingUp className="w-5 h-5 mr-2 text-[#1D9BF0]" />
+        What's happening
+      </h2>
+      <ul className="space-y-2 text-sm">
+        {topics.map((t) => (
+          <li key={t.id} className="truncate">{t.text}</li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default TrendingTopics;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,6 +7,7 @@ import { FaHeart, FaComment, FaShare } from "react-icons/fa";
 import { FiCamera } from "react-icons/fi";
 import { motion } from "framer-motion";
 import HeaderSlider from "./components/HeaderSlider";
+import TrendingTopics from "./components/TrendingTopics";
 
 interface UserData {
     _id: string;
@@ -59,6 +60,10 @@ export default function HomePage() {
     const [replyTexts, setReplyTexts] = useState<Record<string, string>>({});
     const [openComments, setOpenComments] = useState<Record<string, boolean>>({});
 
+    const isPro = user?.subscriptionExpiresAt
+        ? new Date(user.subscriptionExpiresAt) > new Date()
+        : false;
+
     const BASE_URL = "https://www.vone.mn";
     // Uploaded files are served from the backend under /api/uploads
     const UPLOADS_URL = `https://www.vone.mn/api/uploads`;
@@ -67,7 +72,9 @@ export default function HomePage() {
     // Fetch posts on mount
     const fetchPosts = useCallback(async () => {
         try {
-            const res = await axios.get(`${BASE_URL}/api/posts`);
+            const res = await axios.get(`${BASE_URL}/api/posts`, {
+                params: { sort: "recommendation" },
+            });
             setPosts(res.data);
             setAllPosts(res.data);
             computeTrendingHashtags(res.data);
@@ -276,6 +283,13 @@ export default function HomePage() {
     return (
         <div className="min-h-screen bg-gray-100 dark:bg-black text-gray-900 dark:text-white">
             <HeaderSlider />
+            {!isPro && (
+                <div className="bg-yellow-500 text-white text-center py-2 px-4">
+                    <Link href="/subscription" className="font-semibold underline">
+                        Subscribe Membership
+                    </Link>
+                </div>
+            )}
             {/* Outer Grid Layout */}
             <div
                 className="mx-auto max-w-5xl w-full grid"
@@ -315,6 +329,7 @@ export default function HomePage() {
                             ))}
                         </div>
                     </div>
+                    <TrendingTopics />
                 </aside>
 
                 {/* Main Content: Create Post & Posts List */}

--- a/src/app/subscription/page.tsx
+++ b/src/app/subscription/page.tsx
@@ -110,8 +110,13 @@ export default function SubscriptionPage() {
                 Сарын Гишүүнчлэл
             </h1>
             <p className="mb-4 text-center text-gray-600">
-                Төлбөр: 1,000₮ / сар
+                Сарын төлбөр: эхний 10 гишүүнд 10,000₮, дараагийн 20 гишүүнд
+                20,000₮
             </p>
+            <div className="mb-6 text-center space-y-1 text-sm text-gray-700">
+                <p>Golomt Bank: <strong>3005127815</strong></p>
+                <p>Khan Bank: <strong>5926153085</strong></p>
+            </div>
 
             {message && (
                 <div className="mb-3 p-2 bg-blue-100 text-blue-800 rounded text-center">


### PR DESCRIPTION
## Summary
- populate user and comment data when sorting posts by recommendation
- show pro subscription pricing and bank accounts in the subscription page

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68482b1a3628832894efdafbe33041b1