### PR TITLE
Add dashboard auth checks and verified icon

### DIFF
--- a/server/routes/user.js
+++ b/server/routes/user.js
@@ -20,7 +20,7 @@ router.get("/active-subscribers", async (req, res) => {
 router.get("/", async (req, res) => {
     try {
         const users = await User.find().select(
-            "username profilePicture rating location"
+            "username profilePicture rating location subscriptionExpiresAt"
         );
         res.json(users);
     } catch (err) {

--- a/src/app/dashboard/members/page.tsx
+++ b/src/app/dashboard/members/page.tsx
@@ -19,6 +19,14 @@ export default function MembersDashboard() {
   const [status, setStatus] = useState("");
 
   useEffect(() => {
+    if (!user) {
+      router.push("/login");
+    } else if (user.username !== "Antaqor") {
+      router.push("/");
+    }
+  }, [user, router]);
+
+  useEffect(() => {
     const fetchMembers = async () => {
       try {
         const res = await fetch(`${BACKEND_URL}/users`);

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,6 +1,8 @@
 // BookDashboardPage.tsx (e.g., in /src/pages/book-dashboard.tsx)
 "use client";
 import React, { useEffect, useState, useRef, FormEvent } from "react";
+import { useRouter } from "next/navigation";
+import { useAuth } from "../context/AuthContext";
 
 interface Book {
     _id: string;
@@ -18,6 +20,16 @@ interface Book {
 const BACKEND_URL = "https://www.vone.mn/api";
 
 export default function BookDashboardPage() {
+    const { user } = useAuth();
+    const router = useRouter();
+
+    useEffect(() => {
+        if (!user) {
+            router.push("/login");
+        } else if (user.username !== "Antaqor") {
+            router.push("/");
+        }
+    }, [user, router]);
     const [books, setBooks] = useState<Book[]>([]);
     const [status, setStatus] = useState("");
 

--- a/src/app/dashboard/points/page.tsx
+++ b/src/app/dashboard/points/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
 import { useAuth } from "../../context/AuthContext";
 
 interface User {
@@ -10,6 +11,15 @@ interface User {
 
 export default function PointsDashboard() {
     const { user } = useAuth();
+    const router = useRouter();
+
+    useEffect(() => {
+        if (!user) {
+            router.push("/login");
+        } else if (user.username !== "Antaqor") {
+            router.push("/");
+        }
+    }, [user, router]);
     const [users, setUsers] = useState<User[]>([]);
 
     useEffect(() => {

--- a/src/app/dashboard/products/page.tsx
+++ b/src/app/dashboard/products/page.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import React, { useEffect, useState, useRef, FormEvent } from "react";
+import { useRouter } from "next/navigation";
+import { useAuth } from "../../context/AuthContext";
 
 /* ── types ─────────────────────────────────────────── */
 interface Product {
@@ -19,6 +21,16 @@ const BACKEND_URL =
 
 /* ── main page component ───────────────────────────── */
 export default function ProductDashboardPage() {
+  const { user } = useAuth();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!user) {
+      router.push("/login");
+    } else if (user.username !== "Antaqor") {
+      router.push("/");
+    }
+  }, [user, router]);
   const [products, setProducts] = useState<Product[]>([]);
   const [status, setStatus] = useState("");
 

--- a/src/app/profile/[id]/page.tsx
+++ b/src/app/profile/[id]/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 import React, { useEffect, useState } from "react";
 import { useRouter, useParams } from "next/navigation";
+import { FaCheckCircle } from "react-icons/fa";
 import axios from "axios";
 
 /**
@@ -90,6 +91,10 @@ export default function PublicProfilePage() {
         return <div className="p-4 text-center">Профайл олдсонгүй</div>;
     }
 
+    const isPro = userData.subscriptionExpiresAt
+        ? new Date(userData.subscriptionExpiresAt) > new Date()
+        : false;
+
     // ---------------- UI ----------------
     return (
         <div className="min-h-screen bg-white dark:bg-dark text-black dark:text-white px-4 py-6 flex flex-col items-center">
@@ -109,7 +114,10 @@ export default function PublicProfilePage() {
                 </div>
 
                 {/* Username + Rating */}
-                <h1 className="text-2xl font-bold text-gray-800">{userData.username}</h1>
+                <div className="flex items-center gap-1">
+                    <h1 className="text-2xl font-bold text-gray-800">{userData.username}</h1>
+                    {isPro && <FaCheckCircle className="text-yellow-400" />}
+                </div>
                 {userData.rating && (
                     <p className="text-sm text-gray-600 mt-1">★ {userData.rating} үнэлгээ</p>
                 )}

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -2,6 +2,7 @@
 import React, { useState, useEffect } from "react";
 import axios from "axios";
 import { useRouter } from "next/navigation";
+import { FaCheckCircle } from "react-icons/fa";
 
 /** Match your user schema. No "name" field. */
 interface UserData {
@@ -102,6 +103,10 @@ export default function MyOwnProfilePage() {
         return <div className="p-4">Өөрийн профайл олдсонгүй.</div>;
     }
 
+    const isPro = userData.subscriptionExpiresAt
+        ? new Date(userData.subscriptionExpiresAt) > new Date()
+        : false;
+
     // ---------------- UI ----------------
     return (
         <div className="min-h-screen bg-white dark:bg-dark text-black dark:text-white font-sans">
@@ -119,9 +124,12 @@ export default function MyOwnProfilePage() {
                 )}
 
                 {/* Username + rating */}
-                <h2 className="text-xl font-bold text-gray-800">
-                    {userData.username}
-                </h2>
+                <div className="flex items-center justify-center gap-1">
+                    <h2 className="text-xl font-bold text-gray-800">
+                        {userData.username}
+                    </h2>
+                    {isPro && <FaCheckCircle className="text-yellow-400" />}
+                </div>
                 {userData.rating && (
                     <p className="text-sm text-gray-600">★ {userData.rating} үнэлгээ</p>
                 )}


### PR DESCRIPTION
## Summary
- show membership expiration in user list responses
- restrict all dashboard pages to `Antaqor`
- display a yellow verified badge on profile pages for members

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684842d113348328944f88a93f145b7a