### PR TITLE
Fix user profile types and lock eslint version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,7 @@
         "@types/react": "^18",
         "@types/react-dom": "^18",
         "autoprefixer": "^10.4.20",
-        "eslint": "^8",
+        "eslint": "8.57.0",
         "eslint-config-next": "15.0.3",
         "jest": "^29.0.0",
         "nodemon": "^2.0.22",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@types/react": "^18",
     "@types/react-dom": "^18",
     "autoprefixer": "^10.4.20",
-    "eslint": "^8",
+    "eslint": "8.57.0",
     "eslint-config-next": "15.0.3",
     "jest": "^29.0.0",
     "nodemon": "^2.0.22",

--- a/src/app/profile/[id]/page.tsx
+++ b/src/app/profile/[id]/page.tsx
@@ -12,6 +12,7 @@ import axios from "axios";
 interface UserData {
     _id: string;
     username: string;
+    coverImage?: string;
     profilePicture?: string;
     rating?: number;
     subscriptionExpiresAt?: string;

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -9,6 +9,7 @@ import { formatPostDate } from "../lib/formatDate";
 interface UserData {
     _id: string;
     username: string;
+    coverImage?: string;
     profilePicture?: string;
     rating?: number;
     subscriptionExpiresAt?: string;


### PR DESCRIPTION
## Summary
- include `coverImage` in user data interfaces so profile pages compile
- pin `eslint` to version 8.57.0 to avoid invalid option errors

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68485344c66883289da04dadb1fde716