### PR TITLE
Add geolocation for feed

### DIFF
--- a/src/app/hooks/useCurrentLocation.ts
+++ b/src/app/hooks/useCurrentLocation.ts
@@ -1,0 +1,28 @@
+import { useEffect, useState } from "react";
+
+export interface Coordinates {
+    latitude: number;
+    longitude: number;
+}
+
+export default function useCurrentLocation() {
+    const [coords, setCoords] = useState<Coordinates | null>(null);
+
+    useEffect(() => {
+        if (!navigator.geolocation) return;
+
+        navigator.geolocation.getCurrentPosition(
+            (pos) => {
+                setCoords({
+                    latitude: pos.coords.latitude,
+                    longitude: pos.coords.longitude,
+                });
+            },
+            (err) => {
+                console.error("Geolocation error", err);
+            }
+        );
+    }, []);
+
+    return coords;
+}


### PR DESCRIPTION
## Summary
- get viewer location with navigator.geolocation
- send coordinates when fetching posts
- rank posts closer to viewer using distance

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684887bd937083288e040305836e362a