### PR TITLE
Add profile avatar nav and edit previews

### DIFF
--- a/src/app/components/Header.tsx
+++ b/src/app/components/Header.tsx
@@ -5,7 +5,8 @@ import { useAuth } from "../context/AuthContext";
 
 export default function Header() {
     const [isMenuOpen, setIsMenuOpen] = useState(false);
-    const { loggedIn, logout } = useAuth();
+    const { loggedIn, logout, user } = useAuth();
+    const BASE_URL = "https://www.vone.mn";
 
     return (
         <>
@@ -21,12 +22,26 @@ export default function Header() {
             <div className="fixed top-0 left-0 w-full z-[999] bg-white dark:bg-dark md:bg-white/80 dark:md:bg-dark/80 backdrop-blur-md">
                 {/* NAV BAR */}
                 <nav className="max-w-7xl mx-auto px-6 py-4 flex items-center">
-                    <div className="ml-auto hidden md:flex items-center space-x-8 font-medium">
-                        {loggedIn ? (
-                            <button
-                                onClick={logout}
-                                className="relative group text-gray-700 dark:text-white hover:text-[#1D9BF0] dark:hover:text-[#1D9BF0]"
-                            >
+                    <div className="ml-auto flex items-center space-x-4">
+                        {loggedIn && (
+                            <Link href="/profile" aria-label="Profile">
+                                {user?.profilePicture ? (
+                                    <img
+                                        src={`${BASE_URL}${user.profilePicture}`}
+                                        alt="Profile"
+                                        className="w-8 h-8 rounded-full object-cover"
+                                    />
+                                ) : (
+                                    <div className="w-8 h-8 rounded-full bg-gray-300" />
+                                )}
+                            </Link>
+                        )}
+                        <div className="hidden md:flex items-center space-x-8 font-medium">
+                            {loggedIn ? (
+                                <button
+                                    onClick={logout}
+                                    className="relative group text-gray-700 dark:text-white hover:text-[#1D9BF0] dark:hover:text-[#1D9BF0]"
+                                >
                                 Гарах
                                 <span className="absolute left-0 bottom-0 w-full h-0.5 bg-[#1D9BF0] scale-x-0 group-hover:scale-x-100 transition-transform origin-left" />
                             </button>
@@ -48,18 +63,19 @@ export default function Header() {
                                 </Link>
                             </>
                         )}
-                    </div>
+                        </div>
 
-                    {/* Hamburger (Mobile Only) */}
-                    <button
-                        className="md:hidden focus:outline-none"
-                        onClick={() => setIsMenuOpen(true)}
-                        aria-label="Toggle Menu"
-                    >
-                        <span className="block w-6 h-0.5 bg-gray-800 dark:bg-white mb-1" />
-                        <span className="block w-6 h-0.5 bg-gray-800 dark:bg-white mb-1" />
-                        <span className="block w-6 h-0.5 bg-gray-800 dark:bg-white" />
-                    </button>
+                        {/* Hamburger (Mobile Only) */}
+                        <button
+                            className="md:hidden focus:outline-none"
+                            onClick={() => setIsMenuOpen(true)}
+                            aria-label="Toggle Menu"
+                        >
+                            <span className="block w-6 h-0.5 bg-gray-800 dark:bg-white mb-1" />
+                            <span className="block w-6 h-0.5 bg-gray-800 dark:bg-white mb-1" />
+                            <span className="block w-6 h-0.5 bg-gray-800 dark:bg-white" />
+                        </button>
+                    </div>
                 </nav>
 
                 {/* FULL-SCREEN MOBILE DRAWER */}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -481,7 +481,7 @@ export default function HomePage() {
                             <img
                               src={`${UPLOADS_URL}/${post.image}`}
                               alt="Post"
-                              className="w-full aspect-video object-cover rounded-lg"
+                              className="w-full h-auto object-cover rounded-lg"
                               onError={(e) => (e.currentTarget.style.display = "none")}
                             />
                           </div>

--- a/src/app/profile/edit/page.tsx
+++ b/src/app/profile/edit/page.tsx
@@ -8,11 +8,17 @@ export default function EditProfilePage() {
   const router = useRouter();
   const [profileFile, setProfileFile] = useState<File | null>(null);
   const [coverFile, setCoverFile] = useState<File | null>(null);
+  const [profilePreview, setProfilePreview] = useState<string | null>(null);
+  const [coverPreview, setCoverPreview] = useState<string | null>(null);
   const [status, setStatus] = useState("");
 
   useEffect(() => {
     if (!loading && !user) {
       router.push("/login");
+    }
+    if (user) {
+      setProfilePreview(user.profilePicture ? `https://www.vone.mn${user.profilePicture}` : null);
+      setCoverPreview(user.coverImage ? `https://www.vone.mn${user.coverImage}` : null);
     }
   }, [user, loading, router]);
 
@@ -47,11 +53,37 @@ export default function EditProfilePage() {
       <form onSubmit={handleSubmit} className="space-y-4">
         <div>
           <label className="block mb-1">Profile Picture</label>
-          <input type="file" accept="image/*" onChange={e => setProfileFile(e.target.files?.[0] || null)} />
+          {profilePreview && (
+            <img src={profilePreview} alt="Profile preview" className="w-24 h-24 object-cover rounded-full mb-2" />
+          )}
+          <input
+            type="file"
+            accept="image/*"
+            onChange={e => {
+              const file = e.target.files?.[0] || null;
+              setProfileFile(file);
+              if (file) {
+                setProfilePreview(URL.createObjectURL(file));
+              }
+            }}
+          />
         </div>
         <div>
           <label className="block mb-1">Cover Image</label>
-          <input type="file" accept="image/*" onChange={e => setCoverFile(e.target.files?.[0] || null)} />
+          {coverPreview && (
+            <img src={coverPreview} alt="Cover preview" className="w-full h-40 object-cover rounded mb-2" />
+          )}
+          <input
+            type="file"
+            accept="image/*"
+            onChange={e => {
+              const file = e.target.files?.[0] || null;
+              setCoverFile(file);
+              if (file) {
+                setCoverPreview(URL.createObjectURL(file));
+              }
+            }}
+          />
         </div>
         <button type="submit" className="px-4 py-2 bg-blue-600 text-white rounded">Save</button>
       </form>


### PR DESCRIPTION
## Summary
- show logged in avatar in header and link to profile
- allow cover/profile image preview in edit profile page
- support natural image ratio for posts

## Testing
- `npm run lint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68488f67a5508328b1fdaa3d3a4d4c5b