### PR TITLE
Implement login persistence & UI improvements

### DIFF
--- a/src/app/components/Header.tsx
+++ b/src/app/components/Header.tsx
@@ -1,6 +1,7 @@
 "use client";
 import React, { useState } from "react";
 import Link from "next/link";
+import { UserCircleIcon } from "@heroicons/react/24/solid";
 import { useAuth } from "../context/AuthContext";
 
 export default function Header() {
@@ -23,7 +24,7 @@ export default function Header() {
                 {/* NAV BAR */}
                 <nav className="max-w-7xl mx-auto px-6 py-4 flex items-center">
                     <div className="ml-auto flex items-center space-x-4">
-                        {loggedIn && (
+                        {loggedIn ? (
                             <Link href="/profile" aria-label="Profile">
                                 {user?.profilePicture ? (
                                     <img
@@ -35,20 +36,33 @@ export default function Header() {
                                     <div className="w-8 h-8 rounded-full bg-gray-300" />
                                 )}
                             </Link>
+                        ) : (
+                            <Link href="/login" aria-label="Login">
+                                <UserCircleIcon className="w-8 h-8 text-yellow-400" />
+                            </Link>
                         )}
                         <div className="hidden md:flex items-center space-x-8 font-medium">
                             {loggedIn ? (
-                                <button
-                                    onClick={logout}
-                                    className="relative group text-gray-700 dark:text-white hover:text-[#1D9BF0] dark:hover:text-[#1D9BF0]"
-                                >
-                                Гарах
-                                <span className="absolute left-0 bottom-0 w-full h-0.5 bg-[#1D9BF0] scale-x-0 group-hover:scale-x-100 transition-transform origin-left" />
-                            </button>
-                        ) : (
-                            <>
-                                <Link
-                                    href="/login"
+                                <>
+                                    <Link
+                                        href="/subscription"
+                                        className="relative group text-gray-700 dark:text-white hover:text-[#1D9BF0] dark:hover:text-[#1D9BF0]"
+                                    >
+                                        Subscription
+                                        <span className="absolute left-0 bottom-0 w-full h-0.5 bg-[#1D9BF0] scale-x-0 group-hover:scale-x-100 transition-transform origin-left" />
+                                    </Link>
+                                    <button
+                                        onClick={logout}
+                                        className="relative group text-gray-700 dark:text-white hover:text-[#1D9BF0] dark:hover:text-[#1D9BF0]"
+                                    >
+                                        Гарах
+                                        <span className="absolute left-0 bottom-0 w-full h-0.5 bg-[#1D9BF0] scale-x-0 group-hover:scale-x-100 transition-transform origin-left" />
+                                    </button>
+                                </>
+                            ) : (
+                                <>
+                                    <Link
+                                        href="/login"
                                     className="relative group text-gray-700 dark:text-white hover:text-[#1D9BF0] dark:hover:text-[#1D9BF0]"
                                 >
                                     Нэвтрэх
@@ -110,17 +124,28 @@ export default function Header() {
                         <nav className="mt-8 px-4">
                             <ul className="space-y-6">
                                 {loggedIn ? (
-                                    <li>
-                                        <button
-                                            onClick={() => {
-                                                logout();
-                                                setIsMenuOpen(false);
-                                            }}
-                                            className="block text-left w-full text-xl font-medium text-gray-800 dark:text-white hover:text-[#1D9BF0] dark:hover:text-[#1D9BF0]"
-                                        >
-                                            Гарах
-                                        </button>
-                                    </li>
+                                    <>
+                                        <li>
+                                            <Link
+                                                href="/subscription"
+                                                onClick={() => setIsMenuOpen(false)}
+                                                className="block text-xl font-medium text-gray-800 dark:text-white hover:text-[#1D9BF0] dark:hover:text-[#1D9BF0]"
+                                            >
+                                                Subscription
+                                            </Link>
+                                        </li>
+                                        <li>
+                                            <button
+                                                onClick={() => {
+                                                    logout();
+                                                    setIsMenuOpen(false);
+                                                }}
+                                                className="block text-left w-full text-xl font-medium text-gray-800 dark:text-white hover:text-[#1D9BF0] dark:hover:text-[#1D9BF0]"
+                                            >
+                                                Гарах
+                                            </button>
+                                        </li>
+                                    </>
                                 ) : (
                                     <>
                                         <li>
@@ -240,6 +265,31 @@ export default function Header() {
                                             Дэлгүүр
                                         </Link>
                                     </li>
+                                    {loggedIn && (
+                                        <li>
+                                            <Link
+                                                href="/subscription"
+                                                onClick={() => setIsMenuOpen(false)}
+                                                className="flex items-center gap-2 hover:text-[#1D9BF0] dark:hover:text-[#1D9BF0]"
+                                            >
+                                                <svg
+                                                    xmlns="http://www.w3.org/2000/svg"
+                                                    className="w-6 h-6"
+                                                    fill="none"
+                                                    viewBox="0 0 24 24"
+                                                    stroke="currentColor"
+                                                >
+                                                    <path
+                                                        strokeLinecap="round"
+                                                        strokeLinejoin="round"
+                                                        strokeWidth="2"
+                                                        d="M13 7h8m0 0v8m0-8l-8 8-4-4-6 6"
+                                                    />
+                                                </svg>
+                                                Subscription
+                                            </Link>
+                                        </li>
+                                    )}
                                     <li>
                                         <Link
                                             href="/users"

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,5 +1,5 @@
 "use client";
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import axios from "axios";
 import { useRouter } from "next/navigation";
 import { useAuth } from "@/app/context/AuthContext";
@@ -9,9 +9,23 @@ export default function LoginPage() {
     const { login } = useAuth();
     const [username, setUsername] = useState("");
     const [password, setPassword] = useState("");
+    const [remember, setRemember] = useState(false);
     const [error, setError] = useState("");
 
     const BASE_URL = "https://www.vone.mn";
+
+    useEffect(() => {
+        const savedUser = localStorage.getItem("rememberUsername");
+        const savedPass = localStorage.getItem("rememberPassword");
+        if (savedUser) {
+            setUsername(savedUser);
+            setRemember(true);
+        }
+        if (savedPass) {
+            setPassword(savedPass);
+            setRemember(true);
+        }
+    }, []);
 
     const handleSubmit = async (e: React.FormEvent) => {
         e.preventDefault();
@@ -25,6 +39,13 @@ export default function LoginPage() {
             if (res.status === 200 && res.data.token) {
                 const { user, token } = res.data;
                 login(user, token);
+                if (remember) {
+                    localStorage.setItem("rememberUsername", username);
+                    localStorage.setItem("rememberPassword", password);
+                } else {
+                    localStorage.removeItem("rememberUsername");
+                    localStorage.removeItem("rememberPassword");
+                }
                 router.push("/");
             }
         } catch (err: any) {
@@ -67,7 +88,12 @@ export default function LoginPage() {
                     </div>
                     <div className="flex items-center justify-between text-sm text-gray-700 dark:text-white">
                         <label className="flex items-center text-black dark:text-white">
-                            <input type="checkbox" className="h-4 w-4 mr-2" />
+                            <input
+                                type="checkbox"
+                                className="h-4 w-4 mr-2"
+                                checked={remember}
+                                onChange={(e) => setRemember(e.target.checked)}
+                            />
                             Сануулах
                         </label>
                         <button

--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -183,6 +183,8 @@ export default function RegisterMultiStepPage() {
                 setGender("");
                 setLocation("");
                 setProfilePicture(null);
+                // Redirect new users to login page
+                router.push("/login");
             }
         } catch (err: any) {
             console.error("Register error:", err);


### PR DESCRIPTION
## Summary
- remember login credentials on request
- redirect newly registered users to the login page
- show yellow login icon for guests
- expose subscription link after login

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68489d24b76c83288242b10b3a05e0f2