### PR TITLE
Restrict feed for non‑subscribed users

### DIFF
--- a/server/routes/post.js
+++ b/server/routes/post.js
@@ -187,6 +187,7 @@ router.post("/:id/like", authenticateToken, async (req, res) => {
 
     post.likes.push(req.user._id);
     await post.save();
+    await User.findByIdAndUpdate(req.user._id, { $inc: { rating: 1 } });
     await post.populate("likes", "username");
 
     res.json({ message: "Post liked", likesCount: post.likes.length, likes: post.likes });

--- a/src/app/components/Header.tsx
+++ b/src/app/components/Header.tsx
@@ -70,7 +70,7 @@ export default function Header() {
                                 </Link>
                                 <Link
                                     href="/register"
-                                    className="relative group text-gray-700 dark:text-white hover:text-[#1D9BF0] dark:hover:text-[#1D9BF0]"
+                                    className="relative group text-gray-700 dark:text-white hover:text-[#1D9BF0] dark:hover:text-[#1D9BF0] bg-yellow-300 text-black px-2 rounded"
                                 >
                                     Бүртгүүлэх
                                     <span className="absolute left-0 bottom-0 w-full h-0.5 bg-[#1D9BF0] scale-x-0 group-hover:scale-x-100 transition-transform origin-left" />
@@ -161,7 +161,7 @@ export default function Header() {
                                             <Link
                                                 href="/register"
                                                 onClick={() => setIsMenuOpen(false)}
-                                                className="block text-xl font-medium text-gray-800 dark:text-white hover:text-[#1D9BF0] dark:hover:text-[#1D9BF0]"
+                                                className="block text-xl font-medium text-gray-800 dark:text-white hover:text-[#1D9BF0] dark:hover:text-[#1D9BF0] bg-yellow-300 text-black px-2 rounded"
                                             >
                                                 Бүртгүүлэх
                                             </Link>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -103,9 +103,17 @@ export default function HomePage() {
 
       const res = await axios.get(`${BASE_URL}/api/posts`, { params });
 
-      setPosts(res.data);
-      setAllPosts(res.data);
-      computeTrendingHashtags(res.data);
+      let postsData: Post[] = res.data;
+      if (loggedIn && !isPro) {
+        postsData = postsData.filter(
+          (p) =>
+            !/#[Aa][Ii]\b/.test(p.content) && (p.likes?.length || 0) < 5
+        );
+      }
+
+      setPosts(postsData);
+      setAllPosts(postsData);
+      computeTrendingHashtags(postsData);
 
       if (user) {
         const liked = res.data
@@ -200,6 +208,7 @@ export default function HomePage() {
         )
       );
       setLikedPosts((prev) => [...prev, postId]);
+      login({ ...user, rating: (user.rating || 0) + 1 }, user.accessToken);
     } catch (err) {
       console.error("Like error:", err);
     }
@@ -311,7 +320,7 @@ export default function HomePage() {
   return (
     <div className="min-h-screen bg-gray-100 dark:bg-black text-gray-900 dark:text-white">
 
-      {!isPro && (
+      {loggedIn && !isPro && (
         <div className="bg-yellow-500 text-white text-center py-2 px-4">
           <Link href="/subscription" className="font-semibold underline">
             Гишүүн болох – Онцгой боломжуудыг нээх
@@ -362,6 +371,22 @@ export default function HomePage() {
 
         {/* Main – create + feed */}
         <main>
+          {/* Prompt login */}
+          {!loggedIn && (
+            <div className="bg-white dark:bg-black p-6 text-center space-y-3">
+              <p>Feed үзэхийн тулд нэвтрэх эсвэл бүртгүүлэх шаардлагатай.</p>
+              <Link href="/login" className="text-blue-600 underline">
+                Нэвтрэх
+              </Link>
+              <Link
+                href="/register"
+                className="block bg-yellow-300 text-black px-3 py-1 rounded w-fit mx-auto"
+              >
+                Бүртгүүлэх
+              </Link>
+            </div>
+          )}
+
           {/* Create post */}
           {loggedIn && (
             <div className="bg-white dark:bg-black grid gap-4 p-6">

--- a/src/app/subscription/page.tsx
+++ b/src/app/subscription/page.tsx
@@ -62,6 +62,11 @@ export default function SubscriptionPage() {
       <h1 className="text-2xl font-bold mb-4 text-center">Premium Membership</h1>
 
       <p className="mb-2 text-center text-gray-600">
+        Гишүүн болсон хэрэглэгчид #AI зэрэг үнэ цэнтэй нийтлэлүүдийг бүрэн
+        үзэх боломжтой.
+      </p>
+
+      <p className="mb-2 text-center text-gray-600">
         Нэгдүгээр 10 гишүүнд 10,000₮, дараагийнх нь 20,000₮ – амжилтыг өнөөдөр эхлүүлье!
       </p>
       <p className="mb-4 text-center text-gray-600">


### PR DESCRIPTION
## Summary
- highlight registration links in the header
- increase user rating when a post is liked
- hide high ranked/#AI posts for non-subscribed users and prompt login on feed
- only show membership banner after login
- note membership benefits on subscription page

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848a67d3e208328bde7d997c648fc37