### PR TITLE
Implement wallet section and login redirect

### DIFF
--- a/src/app/components/BottomNav.tsx
+++ b/src/app/components/BottomNav.tsx
@@ -7,7 +7,7 @@ import {
     MagnifyingGlassIcon,
     PlusCircleIcon,
     BellIcon,
-    EnvelopeIcon,
+    WalletIcon,
 } from "@heroicons/react/24/outline";
 
 const BottomNav: React.FC = () => {
@@ -77,13 +77,13 @@ const BottomNav: React.FC = () => {
                     <BellIcon className="h-7 w-7" />
                 </button>
 
-                {/* MESSAGES */}
+                {/* WALLET */}
                 <button
-                    onClick={() => router.push("/messages")}
-                    aria-label="Messages"
+                    onClick={() => router.push("/wallet")}
+                    aria-label="Wallet"
                     className="p-1 text-black dark:text-white"
                 >
-                    <EnvelopeIcon className="h-7 w-7" />
+                    <WalletIcon className="h-7 w-7" />
                 </button>
             </div>
         </nav>

--- a/src/app/components/Header.tsx
+++ b/src/app/components/Header.tsx
@@ -243,11 +243,11 @@ export default function Header() {
                                         </Link>
                                     </li>
                                     <li>
-                                        <Link
-                                            href="/shop"
-                                            onClick={() => setIsMenuOpen(false)}
-                                            className="flex items-center gap-2 hover:text-[#1D9BF0] dark:hover:text-[#1D9BF0]"
-                                        >
+                                    <Link
+                                        href="/shop"
+                                        onClick={() => setIsMenuOpen(false)}
+                                        className="flex items-center gap-2 hover:text-[#1D9BF0] dark:hover:text-[#1D9BF0]"
+                                    >
                                             <svg
                                                 xmlns="http://www.w3.org/2000/svg"
                                                 className="w-6 h-6"
@@ -262,14 +262,37 @@ export default function Header() {
                                                     d="M16 11V7a4 4 0 00-8 0v4M5 9h14l1 12H4L5 9z"
                                                 />
                                             </svg>
-                                            Дэлгүүр
-                                        </Link>
-                                    </li>
-                                    {loggedIn && (
-                                        <li>
-                                            <Link
-                                                href="/subscription"
-                                                onClick={() => setIsMenuOpen(false)}
+                                        Дэлгүүр
+                                    </Link>
+                                </li>
+                                <li>
+                                    <Link
+                                        href="/wallet"
+                                        onClick={() => setIsMenuOpen(false)}
+                                        className="flex items-center gap-2 hover:text-[#1D9BF0] dark:hover:text-[#1D9BF0]"
+                                    >
+                                        <svg
+                                            xmlns="http://www.w3.org/2000/svg"
+                                            className="w-6 h-6"
+                                            fill="none"
+                                            viewBox="0 0 24 24"
+                                            stroke="currentColor"
+                                        >
+                                            <path
+                                                strokeLinecap="round"
+                                                strokeLinejoin="round"
+                                                strokeWidth="2"
+                                                d="M2.25 6.75h19.5v10.5H2.25zM2.25 9h19.5"
+                                            />
+                                        </svg>
+                                        Wallet
+                                    </Link>
+                                </li>
+                                {loggedIn && (
+                                    <li>
+                                        <Link
+                                            href="/subscription"
+                                            onClick={() => setIsMenuOpen(false)}
                                                 className="flex items-center gap-2 hover:text-[#1D9BF0] dark:hover:text-[#1D9BF0]"
                                             >
                                                 <svg

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -88,6 +88,7 @@ export default function RootLayout({
                 <main className="flex-grow flex flex-col md:flex-row gap-0 pt-16">
                     {/* Зүүн талын Sidebar */}
                     <aside className="hidden md:block w-full md:w-1/4 border-r border-gray-200 dark:border-gray-700 sticky top-16 h-[calc(100vh-80px)] overflow-y-auto fade-in-up">
+                        <div className="p-4 font-semibold">Wallet: 0 VNT</div>
                         <nav>
                             <ul className="space-y-1">
                                 <li>
@@ -204,6 +205,28 @@ export default function RootLayout({
                                             />
                                         </svg>
                                         <span className="dark:text-white">Дэлгүүр</span>
+                                    </Link>
+                                </li>
+                                <li>
+                                    <Link
+                                        href="/wallet"
+                                        className="group flex items-center gap-2 p-4 pl-0 text-xl font-semibold text-gray-700 dark:text-white transition-smooth focus:outline-none hover:text-[#1D9BF0] dark:hover:text-[#1D9BF0] focus:ring-2 focus:ring-[#1D9BF0]"
+                                    >
+                                        <svg
+                                            xmlns="http://www.w3.org/2000/svg"
+                                            className="w-6 h-6 group-hover:text-[#1D9BF0] dark:text-white dark:group-hover:text-[#1D9BF0]"
+                                            fill="none"
+                                            viewBox="0 0 24 24"
+                                            stroke="currentColor"
+                                        >
+                                            <path
+                                                strokeLinecap="round"
+                                                strokeLinejoin="round"
+                                                strokeWidth="2"
+                                                d="M2.25 6.75h19.5v10.5H2.25zM2.25 9h19.5"
+                                            />
+                                        </svg>
+                                        <span className="dark:text-white">Wallet</span>
                                     </Link>
                                 </li>
                                 <li>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,6 +8,7 @@ import React, {
 } from "react";
 import axios from "axios";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { useAuth } from "./context/AuthContext";
 import { FaHeart, FaRegHeart, FaComment, FaShare } from "react-icons/fa";
 import { FiCamera } from "react-icons/fi";
@@ -63,7 +64,8 @@ interface Hashtag {
 // Component
 // ────────────────────────────────────────────────────────────────
 export default function HomePage() {
-  const { user, loggedIn, login } = useAuth();
+  const { user, loggedIn, loading, login } = useAuth();
+  const router = useRouter();
 
   const [posts, setPosts] = useState<Post[]>([]);
   const [allPosts, setAllPosts] = useState<Post[]>([]);
@@ -88,6 +90,12 @@ export default function HomePage() {
   const BASE_URL = "https://www.vone.mn";
   const UPLOADS_URL = `${BASE_URL}/api/uploads`;
   const fileInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (!loading && !loggedIn) {
+      router.push("/login");
+    }
+  }, [loading, loggedIn, router]);
 
   // ────────────────────────────────────────────────────────────
   // Fetch posts (location-aware “smart” sort)

--- a/src/app/wallet/page.tsx
+++ b/src/app/wallet/page.tsx
@@ -1,0 +1,24 @@
+"use client";
+import React from "react";
+import { useAuth } from "../context/AuthContext";
+
+export default function WalletPage() {
+  const { loggedIn } = useAuth();
+
+  if (!loggedIn) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <p>You must log in to view your wallet.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center">
+      <div className="text-center space-y-4">
+        <h1 className="text-2xl font-bold">Wallet</h1>
+        <p className="text-xl">Balance: 0 VNT</p>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- redirect unauthenticated users from the feed to `/login`
- replace message button with wallet in bottom navigation
- display wallet balance on sidebar and link to wallet page
- add wallet link to the mobile drawer
- create simple wallet page showing VNT balance

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848ab6ac9ac83289f159f7edbc18876