### PR TITLE
Add paid post capability

### DIFF
--- a/server/middleware/authMiddleware.js
+++ b/server/middleware/authMiddleware.js
@@ -12,7 +12,7 @@ const authenticateToken = async (req, res, next) => {
     try {
         const decoded = jwt.verify(token, process.env.JWT_SECRET || "change-me");
         const user = await User.findById(decoded.id).select(
-            "username phoneNumber location gender birthday profilePicture subscriptionExpiresAt following followers"
+            "username phoneNumber location gender birthday profilePicture subscriptionExpiresAt following followers vntBalance"
         );
         if (!user) {
             return res.status(401).json({ error: "User not found" });

--- a/server/models/Post.js
+++ b/server/models/Post.js
@@ -19,6 +19,8 @@ const PostSchema = new Schema(
         user: { type: mongoose.Schema.Types.ObjectId, ref: "User", required: true },
         content: { type: String, required: true },
         image: { type: String }, // stores just the filename, e.g., "123456789-image.png"
+        price: { type: Number, default: 0 },
+        unlockedBy: [{ type: mongoose.Schema.Types.ObjectId, ref: "User" }],
         likes: [{ type: mongoose.Schema.Types.ObjectId, ref: "User" }],
         comments: [CommentSchema],
         shares: { type: Number, default: 0 },

--- a/src/app/new-post/page.tsx
+++ b/src/app/new-post/page.tsx
@@ -11,6 +11,8 @@ export default function NewPostPage() {
     const { user } = useAuth();
     const [content, setContent] = useState("");
     const [imageFile, setImageFile] = useState<File | null>(null);
+    const [postType, setPostType] = useState("free");
+    const [price, setPrice] = useState(0);
     const [error, setError] = useState("");
     const fileInputRef = useRef<HTMLInputElement>(null);
 
@@ -37,6 +39,7 @@ export default function NewPostPage() {
         try {
             const formData = new FormData();
             formData.append("content", content);
+            formData.append("price", postType === "paid" ? String(price) : "0");
             if (imageFile) formData.append("image", imageFile);
 
             await axios.post(`${BASE_URL}/api/posts`, formData, {
@@ -74,6 +77,37 @@ export default function NewPostPage() {
                     <span className="block text-xs text-gray-700 truncate">
                         {imageFile.name}
                     </span>
+                )}
+                <div className="space-x-2 text-sm">
+                    <label>
+                        <input
+                            type="radio"
+                            name="type"
+                            value="free"
+                            checked={postType === "free"}
+                            onChange={() => setPostType("free")}
+                        />
+                        Free
+                    </label>
+                    <label>
+                        <input
+                            type="radio"
+                            name="type"
+                            value="paid"
+                            checked={postType === "paid"}
+                            onChange={() => setPostType("paid")}
+                        />
+                        Paid
+                    </label>
+                </div>
+                {postType === "paid" && (
+                    <input
+                        type="number"
+                        className="w-32 p-1 text-sm bg-gray-200 dark:bg-gray-800 rounded"
+                        placeholder="Price (VNT)"
+                        value={price}
+                        onChange={(e) => setPrice(Number(e.target.value))}
+                    />
                 )}
                 <textarea
                     placeholder="What's on your mind?"


### PR DESCRIPTION
## Summary
- allow posts to include price and unlocked state
- capture user balance info in auth middleware
- support paid posting and unlocking posts on backend
- add Free/Paid option and price field when creating a post
- blur locked posts in feed with Unlock button

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848b356893483289c324999a01b45f1