### PR TITLE
Fix userId usage when unlocking posts

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -285,10 +285,11 @@ export default function HomePage() {
         {},
         { headers: { Authorization: `Bearer ${user.accessToken}` } }
       );
+      const userId = user._id!;
       setPosts((prev) =>
         prev.map((p) =>
           p._id === postId
-            ? { ...p, unlockedBy: [...(p.unlockedBy || []), user._id] }
+            ? { ...p, unlockedBy: [...(p.unlockedBy || []), userId] }
             : p
         )
       );


### PR DESCRIPTION
## Summary
- ensure the user ID is non-null when unlocking posts

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848b5671ee8832897e443c6089d8364