### PR TITLE
Persist vntBalance in AuthContext

### DIFF
--- a/src/app/context/AuthContext.tsx
+++ b/src/app/context/AuthContext.tsx
@@ -21,6 +21,7 @@ export interface AuthUser {
     subscriptionExpiresAt?: string;
     following?: string[];
     followers?: string[];
+    vntBalance?: number;
     accessToken?: string;
 }
 
@@ -54,6 +55,9 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
             try {
                 const parsed = JSON.parse(storedUserStr) as AuthUser;
                 parsed.accessToken = token;
+                if (typeof parsed.vntBalance === "string") {
+                    parsed.vntBalance = Number(parsed.vntBalance);
+                }
                 setUser(parsed);
                 setLoggedIn(true);
             } catch {
@@ -67,6 +71,10 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         const userWithSubscription = {
             ...newUser,
             subscriptionExpiresAt: newUser.subscriptionExpiresAt,
+            vntBalance:
+                newUser.vntBalance !== undefined
+                    ? newUser.vntBalance
+                    : user?.vntBalance,
             accessToken: token,
         };
         localStorage.setItem("user", JSON.stringify(userWithSubscription));


### PR DESCRIPTION
## Summary
- track VNT balance on `AuthUser`
- keep the balance when reading from storage or when logging in

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848b574e9648328b0ed8ccfb15ce462