### PR TITLE
Fix unlocking state update

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -270,7 +270,7 @@ export default function HomePage() {
   };
 
   const handleUnlock = async (postId: string) => {
-    if (!user?.accessToken) return;
+    if (!user || !user._id || !user.accessToken) return;
     try {
       const { data } = await axios.post(
         `${BASE_URL}/api/posts/${postId}/unlock`,
@@ -282,7 +282,7 @@ export default function HomePage() {
       setPosts((prev) =>
         prev.map((p) =>
           p._id === postId
-            ? { ...p, unlockedBy: [...(p.unlockedBy || []), userId] }
+            ? { ...p, unlockedBy: [...(p.unlockedBy ?? []), userId] }
             : p
         )
       );


### PR DESCRIPTION
## Summary
- fix type error by ensuring user is available in `handleUnlock`
- use nullish coalescing when updating the `unlockedBy` array

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848b8ccb8388328bee51bc5110d8c59