### PR TITLE
Fix profile locked posts overlay

### DIFF
--- a/src/app/components/PostCard.tsx
+++ b/src/app/components/PostCard.tsx
@@ -1,8 +1,9 @@
 "use client";
-import React from "react";
+import React, { useState } from "react";
 import { FaCheckCircle } from "react-icons/fa";
 import { formatPostDate } from "../lib/formatDate";
 import { useAuth } from "../context/AuthContext";
+import axios from "axios";
 
 interface User {
   _id?: string;
@@ -33,15 +34,36 @@ const BASE_URL = "https://www.vone.mn";
 const UPLOADS_URL = `${BASE_URL}/api/uploads`;
 
 export default function PostCard({ post, user }: Props) {
-  const { user: viewer } = useAuth();
+  const { user: viewer, login } = useAuth();
   const isPro = user.subscriptionExpiresAt
     ? new Date(user.subscriptionExpiresAt) > new Date()
     : false;
   const viewerId = viewer?._id;
   const authorId = user._id || post.user?._id;
-  const isLocked =
-    !!post.price && post.price > 0 &&
-    (!viewerId || (authorId !== viewerId && !post.unlockedBy?.some((u: any) => (u._id || u) === viewerId)));
+  const initiallyLocked =
+    !!post.price &&
+    post.price > 0 &&
+    (!viewerId ||
+      (authorId !== viewerId &&
+        !post.unlockedBy?.some((u: any) => (u._id || u) === viewerId)));
+  const [locked, setLocked] = useState(initiallyLocked);
+
+  const handleUnlock = async () => {
+    if (!viewer || !viewer._id || !viewer.accessToken) return;
+    try {
+      const { data } = await axios.post(
+        `${BASE_URL}/api/posts/${post._id}/unlock`,
+        {},
+        { headers: { Authorization: `Bearer ${viewer.accessToken}` } }
+      );
+      setLocked(false);
+      if (typeof data.vntBalance === "number") {
+        login({ ...viewer, vntBalance: data.vntBalance }, viewer.accessToken);
+      }
+    } catch (err) {
+      console.error("Unlock error:", err);
+    }
+  };
   return (
     <div className="tweet border-b border-gray-700 p-4 max-w-xl mx-auto relative">
       <div className="flex gap-3">
@@ -62,24 +84,37 @@ export default function PostCard({ post, user }: Props) {
               {formatPostDate(post.createdAt)}
             </span>
           </div>
-          {isLocked ? (
-            <div className="flex items-center justify-center h-28 bg-gray-800 rounded">
-              <span className="text-xs text-white">Paid post – unlock to view</span>
-            </div>
-          ) : (
-            <div>
-              <p className="text-gray-200 text-sm mt-1 whitespace-pre-wrap">
+          <div className="relative">
+            {post.content && (
+              <p
+                className={`text-gray-200 text-sm mt-1 whitespace-pre-wrap ${
+                  locked ? "opacity-20" : ""
+                }`}
+              >
                 {post.content}
               </p>
-              {post.image && (
-                <img
-                  src={`${UPLOADS_URL}/${post.image}`}
-                  alt="Post"
-                  className="w-full rounded-lg mt-2 object-cover"
-                />
-              )}
-            </div>
-          )}
+            )}
+            {post.image && (
+              <img
+                src={`${UPLOADS_URL}/${post.image}`}
+                alt="Post"
+                className={`w-full rounded-lg mt-2 object-cover ${locked ? "blur-md" : ""}`}
+              />
+            )}
+            {locked && (
+              <div className="absolute inset-0 flex flex-col items-center justify-center rounded-lg bg-black/50 backdrop-blur-md">
+                <span className="text-xs text-white mb-2">Paid post – unlock to view</span>
+                {post.price && post.price > 0 && (
+                  <button
+                    onClick={handleUnlock}
+                    className="px-3 py-1 text-xs bg-blue-600 text-white rounded"
+                  >
+                    Unlock for {post.price} VNT
+                  </button>
+                )}
+              </div>
+            )}
+          </div>
           <div className="flex justify-between text-gray-400 text-xs mt-3">
             <span>{post.likes?.length || 0} Likes</span>
             <span>{post.comments?.length || 0} Comments</span>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -558,40 +558,36 @@ export default function HomePage() {
                       </span>
 
                       {/* Content */}
-                      {isLocked ? (
-                        <div className="flex items-center justify-center h-32 bg-gray-800 rounded">
-                          <span className="text-xs text-white">Paid post – unlock to view</span>
-                        </div>
-                      ) : (
-                        <div>
-                          {post.content && (
-                            <p className="text-base whitespace-pre-wrap">
-                              {post.content}
-                            </p>
-                          )}
-                          {post.image && (
-                            <div className="relative w-full overflow-hidden rounded-lg mt-2">
-                              <img
-                                src={`${UPLOADS_URL}/${post.image}`}
-                                alt="Post"
-                                className="w-full h-auto object-cover rounded-lg"
-                                onError={(e) => (e.currentTarget.style.display = "none")}
-                              />
-                            </div>
-                          )}
-                        </div>
-                      )}
-
-                      {isLocked && (
-                        <div className="mt-2">
-                          <button
-                            onClick={() => handleUnlock(post._id)}
-                            className="px-3 py-1 text-xs bg-blue-600 text-white rounded"
+                      <div className="relative">
+                        {post.content && (
+                          <p
+                            className={`text-base whitespace-pre-wrap ${isLocked ? "opacity-20" : ""}`}
                           >
-                            Unlock for {post.price} VNT
-                          </button>
-                        </div>
-                      )}
+                            {post.content}
+                          </p>
+                        )}
+                        {post.image && (
+                          <div className="relative w-full overflow-hidden rounded-lg mt-2">
+                            <img
+                              src={`${UPLOADS_URL}/${post.image}`}
+                              alt="Post"
+                              className={`w-full h-auto object-cover rounded-lg ${isLocked ? "blur-md" : ""}`}
+                              onError={(e) => (e.currentTarget.style.display = "none")}
+                            />
+                          </div>
+                        )}
+                        {isLocked && (
+                          <div className="absolute inset-0 flex flex-col items-center justify-center rounded-lg bg-black/50 backdrop-blur-md">
+                            <span className="text-xs text-white mb-2">Paid post – unlock to view</span>
+                            <button
+                              onClick={() => handleUnlock(post._id)}
+                              className="px-3 py-1 text-xs bg-blue-600 text-white rounded"
+                            >
+                              Unlock for {post.price} VNT
+                            </button>
+                          </div>
+                        )}
+                      </div>
                     </div>
                   </div>
 


### PR DESCRIPTION
## Summary
- show unlock button for paid posts on profile pages
- blur locked content on both feed and profile posts

## Testing
- `npm run lint` *(fails: next not found)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68497c8e32508328adb1036d618c8f7f