### PR TITLE
Replace spinner with skeleton overlay

### DIFF
--- a/src/app/components/LoadingOverlay.tsx
+++ b/src/app/components/LoadingOverlay.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { motion } from "framer-motion";
+import LoadingSkeleton from "./LoadingSkeleton";
 
 export default function LoadingOverlay() {
   return (
@@ -9,7 +10,9 @@ export default function LoadingOverlay() {
       animate={{ opacity: 1 }}
       exit={{ opacity: 0 }}
     >
-      <div className="loader futuristic" />
+      <div className="w-64 p-4 bg-[#0d0d0d] rounded-lg shadow-md">
+        <LoadingSkeleton lines={4} />
+      </div>
     </motion.div>
   );
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -51,24 +51,7 @@ div {
     transition: all 0.3s cubic-bezier(0.25, 1, 0.5, 1);
 }
 
-/* Futuristic loading spinner */
-.loader.futuristic {
-    width: 50px;
-    height: 50px;
-    border-radius: 50%;
-    border: 4px solid transparent;
-    border-top-color: #1D9BF0;
-    animation: spin 1s linear infinite;
-}
 
-@keyframes spin {
-    0% {
-        transform: rotate(0deg);
-    }
-    100% {
-        transform: rotate(360deg);
-    }
-}
 
 /* Skeleton placeholder */
 @keyframes pulse {


### PR DESCRIPTION
## Summary
- replace loading spinner overlay with skeleton markup
- remove unused spinner CSS styles

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a6df150688328a9f13d939ec122e9