### PR TITLE
Improve feed loading experience

### DIFF
--- a/src/app/components/LoadingSpinner.tsx
+++ b/src/app/components/LoadingSpinner.tsx
@@ -1,0 +1,9 @@
+"use client";
+
+export default function LoadingSpinner() {
+  return (
+    <div className="flex items-center justify-center py-4" aria-label="Loading">
+      <div className="w-6 h-6 border-2 border-[#1D9BF0] border-t-transparent rounded-full animate-spin" />
+    </div>
+  );
+}

--- a/src/app/components/PostCard.tsx
+++ b/src/app/components/PostCard.tsx
@@ -1,6 +1,7 @@
 "use client";
 import React, { useState } from "react";
 import { FaCheckCircle } from "react-icons/fa";
+import { LockClosedIcon, BoltIcon } from "@heroicons/react/24/solid";
 import { formatPostDate } from "../lib/formatDate";
 import { useAuth } from "../context/AuthContext";
 import axios from "axios";
@@ -83,6 +84,11 @@ export default function PostCard({ post, user }: Props) {
             <span className="text-gray-400 ml-1 text-xs">
               {formatPostDate(post.createdAt)}
             </span>
+            {post.price && post.price > 0 ? (
+              <LockClosedIcon className="w-3 h-3 text-yellow-400 ml-1" />
+            ) : (
+              <BoltIcon className="w-3 h-3 text-green-400 ml-1" />
+            )}
           </div>
           <div className="relative">
             {post.content && (


### PR DESCRIPTION
## Summary
- support pagination in posts API
- add LoadingSpinner component
- modernize icons and add free/paid indicators
- implement infinite scrolling with refresh button

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a705609108328a499cb883e616266