### PR TITLE
Fix JSX closing tags in HomePage

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -811,7 +811,8 @@ export default function HomePage() {
                   )}
                 </motion.div>
               );
-              ))}
+            });
+          )}
             {loadingPosts && pageNum > 1 && <LoadingSpinner />}
             <div ref={loadMoreRef} />
           </div>


### PR DESCRIPTION
## Summary
- fix incorrect closing tokens in `page.tsx`

## Testing
- `npm run build` *(fails: next not found)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684a7c2dab908328a3c0a82f4087208e