### PR TITLE
Fix loader scope and update post UI

### DIFF
--- a/src/app/components/LayoutClient.tsx
+++ b/src/app/components/LayoutClient.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import { usePathname } from "next/navigation";
 import { AuthProvider } from "../context/AuthContext";
 import { CartProvider } from "../context/CartContext";
 import { ThemeProvider } from "../context/ThemeContext";
@@ -15,6 +16,7 @@ import Link from "next/link";
 
 export default function LayoutClient({ children }: { children: React.ReactNode }) {
   const [mountLoading, setMountLoading] = useState(true);
+  const pathname = usePathname();
 
   useEffect(() => {
     const timer = setTimeout(() => setMountLoading(false), 500);
@@ -25,7 +27,10 @@ export default function LayoutClient({ children }: { children: React.ReactNode }
     <ThemeProvider>
       <CartProvider>
         <AuthProvider>
-          {mountLoading && <LoadingOverlay />}
+          {mountLoading &&
+            (pathname === "/" ||
+              pathname.startsWith("/users") ||
+              pathname.startsWith("/profile")) && <LoadingOverlay />}
           <NavigationLoader />
           <div className="max-w-7xl w-full mx-auto md:px-6">
             <SidebarControl />

--- a/src/app/components/NavigationLoader.tsx
+++ b/src/app/components/NavigationLoader.tsx
@@ -7,7 +7,11 @@ export default function NavigationLoader() {
   const [loading, setLoading] = useState(false);
 
   useEffect(() => {
-    const start = () => setLoading(true);
+    const shouldShow = (url: string) =>
+      url === "/" || url.startsWith("/users") || url.startsWith("/profile");
+    const start = (url: string) => {
+      if (shouldShow(url)) setLoading(true);
+    };
     const end = () => setLoading(false);
     Router.events.on("routeChangeStart", start);
     Router.events.on("routeChangeComplete", end);

--- a/src/app/components/PostCard.tsx
+++ b/src/app/components/PostCard.tsx
@@ -66,7 +66,7 @@ export default function PostCard({ post, user }: Props) {
     }
   };
   return (
-    <div className="tweet border-b border-gray-700 p-4 max-w-xl mx-auto relative">
+    <div className="bg-white dark:bg-black p-6 grid gap-4 border-b border-gray-200 dark:border-[#2F3336]">
       <div className="flex gap-3">
         {user.profilePicture ? (
           <img

--- a/src/app/loading.tsx
+++ b/src/app/loading.tsx
@@ -1,5 +1,12 @@
+"use client";
+import { usePathname } from "next/navigation";
 import LoadingOverlay from "./components/LoadingOverlay";
 
 export default function GlobalLoading() {
-  return <LoadingOverlay />;
+  const pathname = usePathname();
+  const show =
+    pathname === "/" ||
+    pathname.startsWith("/users") ||
+    pathname.startsWith("/profile");
+  return show ? <LoadingOverlay /> : null;
 }

--- a/src/app/new-post/page.tsx
+++ b/src/app/new-post/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 import React, { useRef, useState } from "react";
+import { FiCamera } from "react-icons/fi";
 import axios from "axios";
 import { useRouter } from "next/navigation";
 import { useAuth } from "../context/AuthContext";
@@ -71,7 +72,7 @@ export default function NewPostPage() {
                     onClick={triggerFileInput}
                     className="p-2 border border-gray-200 dark:border-black rounded-full hover:bg-gray-100 dark:hover:bg-black"
                 >
-                    Upload Image
+                    <FiCamera className="w-5 h-5 text-[#1D9BF0]" />
                 </button>
                 {imageFile && (
                     <span className="block text-xs text-gray-700 truncate">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -488,7 +488,7 @@ export default function HomePage() {
                   onClick={triggerFileInput}
                   className="p-2 border border-gray-200 dark:border-black rounded-full hover:bg-gray-100 dark:hover:bg-black"
                 >
-                  <FiCamera className="w-5 h-5 text-gray-600 dark:text-white" />
+                  <FiCamera className="w-5 h-5 text-[#1D9BF0]" />
                 </button>
                 {imageFile && (
                   <span className="text-xs text-gray-700 truncate">


### PR DESCRIPTION
## Summary
- show global loading overlay only on feed and member pages
- update NavigationLoader to check target URL
- show initial load overlay only on specific routes
- make upload buttons blue
- align PostCard styling with feed posts

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ab36dd1c483289311106ebc0e7eec