### PR TITLE
Add salon booking page

### DIFF
--- a/src/app/components/BottomNav.tsx
+++ b/src/app/components/BottomNav.tsx
@@ -76,6 +76,22 @@ const BottomNav: React.FC = () => {
                 >
                     <WalletIcon className="h-7 w-7" />
                 </button>
+                {/* SALON */}
+                <button
+                    onClick={() => router.push("/salon")}
+                    aria-label="Salon"
+                    className="p-1 text-black dark:text-white"
+                >
+                    <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        className="h-7 w-7"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                    >
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 7h16M4 12h16M4 17h16" />
+                    </svg>
+                </button>
             </div>
         </nav>
     );

--- a/src/app/components/Header.tsx
+++ b/src/app/components/Header.tsx
@@ -226,6 +226,29 @@ export default function Header() {
                                         Wallet
                                     </Link>
                                 </li>
+                                <li>
+                                    <Link
+                                        href="/salon"
+                                        onClick={() => setIsMenuOpen(false)}
+                                        className="flex items-center gap-2 hover:text-brandPink dark:hover:text-brandPink"
+                                    >
+                                        <svg
+                                            xmlns="http://www.w3.org/2000/svg"
+                                            className="w-6 h-6"
+                                            fill="none"
+                                            viewBox="0 0 24 24"
+                                            stroke="currentColor"
+                                        >
+                                            <path
+                                                strokeLinecap="round"
+                                                strokeLinejoin="round"
+                                                strokeWidth="2"
+                                                d="M4 7h16M4 12h16M4 17h16"
+                                            />
+                                        </svg>
+                                        Salon
+                                    </Link>
+                                </li>
                                 {loggedIn && !isPro && (
                                     <li>
                                         <Link

--- a/src/app/components/LayoutClient.tsx
+++ b/src/app/components/LayoutClient.tsx
@@ -84,6 +84,23 @@ export default function LayoutClient({ children }: { children: React.ReactNode }
                     </li>
                     <li>
                       <Link
+                        href="/salon"
+                        className="group flex items-center gap-2 p-4 pl-0 text-xl font-semibold text-gray-700 dark:text-white transition-smooth focus:outline-none hover:text-brandPink dark:hover:text-brandPink focus:ring-2 focus:ring-brandPink"
+                      >
+                        <svg
+                          xmlns="http://www.w3.org/2000/svg"
+                          className="w-6 h-6 group-hover:text-brandPink dark:text-white dark:group-hover:text-brandPink"
+                          fill="none"
+                          viewBox="0 0 24 24"
+                          stroke="currentColor"
+                        >
+                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M4 7h16M4 12h16M4 17h16" />
+                        </svg>
+                        <span className="dark:text-white">Salon</span>
+                      </Link>
+                    </li>
+                    <li>
+                      <Link
                         href="/users"
                         className="group flex items-center gap-2 p-4 pl-0 text-xl font-semibold text-gray-700 dark:text-white transition-smooth focus:outline-none hover:text-[#1D9BF0] dark:hover:text-[#1D9BF0] focus:ring-2 focus:ring-[#1D9BF0]"
                       >

--- a/src/app/salon/page.tsx
+++ b/src/app/salon/page.tsx
@@ -1,0 +1,79 @@
+"use client";
+import React, { useEffect, useState } from "react";
+
+const times = [
+  "10:00", "11:00", "12:00", "13:00", "14:00", "15:00", "16:00", "17:00",
+];
+
+export default function SalonPage() {
+  const [booked, setBooked] = useState<string[]>([]);
+
+  // Load bookings from localStorage
+  useEffect(() => {
+    const stored = localStorage.getItem("yukiSalonBookings");
+    if (stored) {
+      try {
+        setBooked(JSON.parse(stored));
+      } catch {
+        /* ignore */
+      }
+    }
+  }, []);
+
+  const bookTime = (time: string) => {
+    if (booked.includes(time)) return;
+    const updated = [...booked, time];
+    setBooked(updated);
+    localStorage.setItem("yukiSalonBookings", JSON.stringify(updated));
+  };
+
+  return (
+    <div className="min-h-screen bg-black text-white flex flex-col items-center">
+      <div className="w-full h-60 relative">
+        <img
+          src="https://images.unsplash.com/photo-1522337660859-02fbefca4702?auto=format&fit=crop&w=1350&q=80"
+          alt="Yuki Salon"
+          className="absolute inset-0 w-full h-full object-cover"
+        />
+        <h1 className="absolute bottom-4 left-4 text-3xl font-bold text-brandPink drop-shadow-md">
+          Yuki Salon
+        </h1>
+      </div>
+
+      <div className="max-w-md w-full p-4 space-y-4">
+        <h2 className="text-2xl font-semibold text-center text-brandPink">
+          Book your time
+        </h2>
+        <ul className="grid grid-cols-2 gap-4">
+          {times.map((t) => (
+            <li key={t}>
+              <button
+                onClick={() => bookTime(t)}
+                disabled={booked.includes(t)}
+                className={`w-full py-2 rounded text-sm font-medium transition-colors ${
+                  booked.includes(t)
+                    ? "bg-gray-500 cursor-not-allowed"
+                    : "bg-brandPink hover:bg-pink-600"
+                }`}
+              >
+                {booked.includes(t) ? `Booked ${t}` : t}
+              </button>
+            </li>
+          ))}
+        </ul>
+        {booked.length > 0 && (
+          <div className="mt-4">
+            <h3 className="text-lg font-semibold mb-2 text-brandPink">
+              Your bookings
+            </h3>
+            <ul className="space-y-1 text-sm">
+              {booked.map((b) => (
+                <li key={b}>{b}</li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- create `/salon` page for Yuki Salon profile
- allow visitors to book time slots stored in localStorage
- add navigation link to the new page in header, side bar and bottom nav

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c3797d64c832892408f5dfb6a0b7a