### PR TITLE
Add slider and glass header

### DIFF
--- a/src/app/components/Header.tsx
+++ b/src/app/components/Header.tsx
@@ -23,7 +23,7 @@ export default function Header() {
                 `}</style>
             )}
 
-            <div className="fixed top-0 left-0 w-full z-[999] bg-black/70 dark:bg-black/70 backdrop-blur-md border-b-2 border-brandCyan">
+            <div className="fixed top-0 left-0 w-full z-[999] bg-white/30 dark:bg-white/10 backdrop-blur-xl shadow-md">
                 {/* NAV BAR */}
                 <nav className="max-w-7xl mx-auto px-6 py-4 flex items-center">
                     <div className="ml-auto flex items-center space-x-4">

--- a/src/app/components/HomeSlider.tsx
+++ b/src/app/components/HomeSlider.tsx
@@ -1,0 +1,34 @@
+"use client";
+import Slider from "react-slick";
+
+const slides = [
+  { title: "Welcome to VONE", text: "Connect. Innovate. Grow." },
+  { title: "Earn Rewards", text: "Join community events and collect points." },
+  { title: "Explore Talents", text: "Discover inspiring profiles around you." },
+];
+
+export default function HomeSlider() {
+  const settings = {
+    dots: true,
+    infinite: true,
+    speed: 500,
+    slidesToShow: 1,
+    slidesToScroll: 1,
+    autoplay: true,
+    autoplaySpeed: 4000,
+    arrows: false,
+  } as const;
+
+  return (
+    <div className="mb-6">
+      <Slider {...settings}>
+        {slides.map((s, idx) => (
+          <div key={idx} className="h-60 md:h-72 flex flex-col items-center justify-center rounded-lg text-center bg-gradient-to-br from-cyan-600 via-pink-500 to-purple-600">
+            <h2 className="text-2xl font-bold mb-2">{s.title}</h2>
+            <p className="text-sm">{s.text}</p>
+          </div>
+        ))}
+      </Slider>
+    </div>
+  );
+}

--- a/src/app/components/LoadingOverlay.tsx
+++ b/src/app/components/LoadingOverlay.tsx
@@ -5,7 +5,7 @@ import LoadingSpinner from "./LoadingSpinner";
 export default function LoadingOverlay() {
   return (
     <motion.div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/80"
+      className="glitch-bg fixed inset-0 z-50 flex items-center justify-center bg-black/80"
       initial={{ opacity: 0 }}
       animate={{ opacity: 1 }}
       exit={{ opacity: 0 }}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2,6 +2,9 @@
 @tailwind components;
 @tailwind utilities;
 
+@import '~slick-carousel/slick/slick.css';
+@import '~slick-carousel/slick/slick-theme.css';
+
 /* No dark background; let Tailwind's default or overridden classes handle it */
 .square-card {
     border-radius: 0; /* Example custom override */
@@ -61,6 +64,28 @@ div {
 
 .animate-pulse div {
     animation: pulse 1.5s ease-in-out infinite;
+}
+
+@keyframes glitchAnim {
+    0% { transform: translate(0); }
+    20% { transform: translate(-5px, -5px); }
+    40% { transform: translate(5px, 5px); }
+    60% { transform: translate(-5px, 5px); }
+    80% { transform: translate(5px, -5px); }
+    100% { transform: translate(0); }
+}
+
+.glitch-bg::before,
+.glitch-bg::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: inherit;
+    mix-blend-mode: overlay;
+    animation: glitchAnim 0.7s infinite;
+}
+.glitch-bg::after {
+    animation-delay: 0.3s;
 }
 
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -23,6 +23,7 @@ import {
 } from "@heroicons/react/24/outline";
 import { FiCamera } from "react-icons/fi";
 import LoadingSpinner from "./components/LoadingSpinner";
+import HomeSlider from "./components/HomeSlider";
 import { motion } from "framer-motion";
 import { formatPostDate } from "./lib/formatDate";
 import useCurrentLocation from "./hooks/useCurrentLocation";
@@ -421,6 +422,8 @@ export default function HomePage() {
           </Link>
         </div>
       )}
+
+      <HomeSlider />
 
       {/* Outer grid */}
       <div


### PR DESCRIPTION
## Summary
- add a minimal home slider
- remove header border and apply glass look
- add slick styles and glitch effect css
- show glitch animation on page navigation overlay

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d164e1bdc8328970b6b1116b59ce1