### PR TITLE
Add avatar blur effect and update UI

### DIFF
--- a/src/app/components/BottomNav.tsx
+++ b/src/app/components/BottomNav.tsx
@@ -32,7 +32,7 @@ const BottomNav: React.FC = () => {
     return (
         <nav
             className={`fixed bottom-0 left-0 w-full md:hidden transition-all backdrop-blur-xl border-t border-white/30 dark:border-white/10 shadow-lg ${
-                scrolledDown ? "bg-white/30 dark:bg-white/10" : "bg-white/20 dark:bg-white/5"
+                scrolledDown ? "bg-gradient-to-br from-white/40 via-white/20 to-white/10 dark:from-white/20 dark:via-white/10 dark:to-white/5" : "bg-gradient-to-br from-white/30 via-white/10 to-white/5 dark:from-white/10 dark:via-white/5 dark:to-white/0"
             }`}
         >
             <div

--- a/src/app/components/Header.tsx
+++ b/src/app/components/Header.tsx
@@ -40,7 +40,7 @@ export default function Header() {
             )}
 
             <div
-                className={`fixed top-0 left-0 w-full z-[999] bg-white/30 dark:bg-white/10 backdrop-blur-xl shadow-md transition-transform duration-300 ${hideHeader ? "-translate-y-full" : "translate-y-0"}`}
+                className={`fixed top-0 left-0 w-full z-[999] bg-gradient-to-b from-white/40 via-white/20 to-transparent dark:from-white/20 dark:via-white/10 dark:to-transparent backdrop-blur-xl shadow-md transition-transform duration-300 ${hideHeader ? "-translate-y-full" : "translate-y-0"}`}
             >
                 {/* NAV BAR */}
                 <nav className="max-w-7xl mx-auto px-6 py-4 flex items-center">

--- a/src/app/components/PostCard.tsx
+++ b/src/app/components/PostCard.tsx
@@ -79,12 +79,12 @@ export default function PostCard({ post, user }: Props) {
   };
   return (
     <div className="bg-white dark:bg-black p-6 grid gap-4 border-b border-gray-200 dark:border-[#2F3336]">
-      <div className="flex gap-3">
+      <div className="flex gap-3 group">
         {user.profilePicture ? (
           <img
             src={`${BASE_URL}${user.profilePicture}`}
             alt="avatar"
-            className="w-10 h-10 rounded-full object-cover"
+            className="w-10 h-10 rounded-full object-cover blur-sm group-hover:blur-0 transition"
           />
         ) : (
           <div className="w-10 h-10 rounded-full bg-gray-300" />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -329,6 +329,14 @@ export default function HomePage() {
         prev.map((p) => (p._id === postId ? { ...p, shares: data.shares } : p))
       );
       setSharedPosts((prev) => [...prev, postId]);
+      const postToShare = posts.find((p) => p._id === postId);
+      const shareLink = `${window.location.origin}/profile/${postToShare?.user?._id || ""}?post=${postId}`;
+      try {
+        await navigator.clipboard.writeText(shareLink);
+        alert("Share link copied!");
+      } catch {
+        console.warn("Clipboard copy failed");
+      }
     } catch (err) {
       console.error("Share error:", err);
     }
@@ -522,14 +530,14 @@ export default function HomePage() {
                     className="bg-white dark:bg-black p-6 grid gap-4 border-b border-gray-200 dark:border-[#2F3336]"
                   >
                     {/* Header */}
-                    <div className="grid grid-cols-[auto,1fr] gap-5">
+                    <div className="grid grid-cols-[auto,1fr] gap-5 group">
                       {/* Avatar */}
                       <div className="self-start">
                         {postUser?.profilePicture ? (
                           <img
                             src={`${BASE_URL}${postUser.profilePicture}`}
                             alt="Avatar"
-                            className="w-12 h-12 object-cover rounded-md"
+                            className="w-12 h-12 object-cover rounded-md blur-sm group-hover:blur-0 transition"
                             onError={(e) => (e.currentTarget.style.display = "none")}
                           />
                         ) : (


### PR DESCRIPTION
## Summary
- blur profile photos in the feed and in `PostCard`
- copy a profile share link to clipboard when sharing a post
- enhance bottom navigation glass effect
- add gradient glass header background

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d243b00688328a8e75e499703f9c9