### PR TITLE
Switch to light theme and update branding

### DIFF
--- a/src/app/components/BottomNav.tsx
+++ b/src/app/components/BottomNav.tsx
@@ -31,8 +31,8 @@ const BottomNav: React.FC = () => {
 
     return (
         <nav
-            className={`fixed bottom-0 left-0 w-full md:hidden transition-all backdrop-blur-xl border-t border-white/30 dark:border-white/10 shadow-lg ${
-                scrolledDown ? "bg-gradient-to-br from-white/40 via-white/20 to-white/10 dark:from-white/20 dark:via-white/10 dark:to-white/5" : "bg-gradient-to-br from-white/30 via-white/10 to-white/5 dark:from-white/10 dark:via-white/5 dark:to-white/0"
+            className={`fixed bottom-0 left-0 w-full md:hidden transition-all backdrop-blur-xl border-t border-supportBorder shadow-lg ${
+                scrolledDown ? "bg-gradient-to-br from-white/40 via-white/20 to-white/10" : "bg-gradient-to-br from-white/30 via-white/10 to-white/5"
             }`}
         >
             <div

--- a/src/app/components/Header.tsx
+++ b/src/app/components/Header.tsx
@@ -44,8 +44,8 @@ export default function Header() {
             >
                 {/* NAV BAR */}
                 <nav className="max-w-7xl mx-auto px-6 py-4 flex items-center">
-                    <Link href="/" className="flex items-center" aria-label="Home">
-                        <img src="/antaqor-wolf.svg" alt="Antaqor" className="w-8 h-8 mr-4" />
+                    <Link href="/" className="flex items-center text-2xl font-bold text-brandCyan" aria-label="Home">
+                        Vone
                     </Link>
                     <div className="ml-auto flex items-center space-x-4">
                         {loggedIn ? (
@@ -199,7 +199,7 @@ export default function Header() {
                             </ul>
 
                             {/* Additional Nav Items */}
-                            <div className="mt-10 border-t border-gray-200 dark:border-gray-700 pt-6">
+                            <div className="mt-10 border-t border-supportBorder pt-6">
                                 <ul className="space-y-4 text-lg font-semibold text-gray-700 dark:text-white">
                                     <li>
                                         <Link

--- a/src/app/components/LayoutClient.tsx
+++ b/src/app/components/LayoutClient.tsx
@@ -37,7 +37,7 @@ export default function LayoutClient({ children }: { children: React.ReactNode }
             <main className="flex-grow flex flex-col md:flex-row gap-0 pt-16">
               <aside
                 id="left-sidebar"
-                className="hidden md:block w-full md:w-1/4 border-r border-gray-200 dark:border-gray-700 sticky top-16 h-[calc(100vh-80px)] overflow-y-auto fade-in-up"
+                className="hidden md:block w-full md:w-1/4 border-r border-supportBorder sticky top-16 h-[calc(100vh-80px)] overflow-y-auto fade-in-up"
               >
                 <nav>
                   <ul className="space-y-1">
@@ -83,7 +83,7 @@ export default function LayoutClient({ children }: { children: React.ReactNode }
                   </ul>
                 </nav>
               </aside>
-              <div className="w-full md:w-1/2 md:border-r md:border-gray-200 dark:md:border-gray-700">
+              <div className="w-full md:w-1/2 md:border-r md:border-supportBorder">
                 <div className="space-y-6">{children}</div>
               </div>
               <aside
@@ -127,7 +127,7 @@ export default function LayoutClient({ children }: { children: React.ReactNode }
               </aside>
             </main>
           </div>
-          <footer className="w-full text-sm text-center py-4 border-t border-gray-300">
+          <footer className="w-full text-sm text-center py-4 border-t border-supportBorder">
             <p className="text-gray-600">© 2025 THE VONE CLAN. Бүх эрх хуулиар хамгаалагдсан.</p>
           </footer>
           <BottomNav />

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -17,10 +17,10 @@ body {
 }
 
 html {
-    background-color: #000000;
-    color-scheme: dark;
+    background-color: #ffffff;
+    color-scheme: light;
     --brand-color: #00FFFC;
-    --brand-hover: #00d4d4;
+    --support-border: #F6F3E1;
 }
 
 /* Minimal fade-in-up animation for sidebars */

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,14 +6,14 @@ import LayoutClient from "./components/LayoutClient";
 const inter = Inter({ subsets: ["latin"] });
 
 export const metadata: Metadata = {
-    metadataBase: new URL(" https://www.vone.mn"),
+    metadataBase: new URL("https://www.vone.mn"),
     title: {
         default: "VONE",
         template: "%s | VONE",
     },
-    description: "VONE - Сүлжээ ба инновацийн дараагийн үеийн платформ.",
-    keywords: ["VONE", "Community", "DAO", "Network", "Zaluusiin Network"],
-    authors: [{ name: "Vone Tech", url: " https://www.vone.mn" }],
+    description: "VONE - Сүлжээ, инноваци, олон нийтийн хүчийг нэгтгэсэн платформ.",
+    keywords: ["VONE", "Community", "DAO", "Network", "Innovation", "Social Network"],
+    authors: [{ name: "Vone Tech", url: "https://www.vone.mn" }],
     verification: {
         google: "YOUR_GOOGLE_SITE_VERIFICATION_TOKEN",
         yandex: "YOUR_YANDEX_SITE_VERIFICATION_TOKEN",
@@ -21,7 +21,7 @@ export const metadata: Metadata = {
     openGraph: {
         title: "VONE – Дараагийн үеийн платформ",
         description: "VONE CLAN-д нэгдээрэй – Сүлжээ, инновацийн хамт олон.",
-        url: " https://www.vone.mn",
+        url: "https://www.vone.mn",
         siteName: "VONE",
         images: [
             {
@@ -44,10 +44,10 @@ export const metadata: Metadata = {
         creator: "@your_twitter_handle",
     },
     alternates: {
-        canonical: " https://www.vone.mn",
+        canonical: "https://www.vone.mn",
         languages: {
-            "mn-MN": " https://www.vone.mn/mn-mn",
-            "en-US": " https://www.vone.mn/en-us",
+            "mn-MN": "https://www.vone.mn/mn-mn",
+            "en-US": "https://www.vone.mn/en-us",
         },
     },
     icons: {
@@ -63,8 +63,8 @@ export const metadata: Metadata = {
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
     return (
-        <html lang="mn" className="dark">
-            <body className={`${inter.className} flex flex-col min-h-screen bg-black text-white`}>
+        <html lang="mn">
+            <body className={`${inter.className} flex flex-col min-h-screen bg-white text-gray-900`}>
                 <LayoutClient>{children}</LayoutClient>
             </body>
         </html>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,7 +1,6 @@
 // tailwind.config.js
 
 module.exports = {
-  darkMode: 'class',
   content: [
     './src/**/*.{js,ts,jsx,tsx}', // Adjust based on your project structure
     './public/**/*.html',
@@ -9,9 +8,8 @@ module.exports = {
   theme: {
     extend: {
       colors: {
-        dark: '#000000', // Pure black for dark mode background
-        light: '#ffffff', // Light color for text
-        brandCyan: '#00FFFC'
+        brandCyan: '#00FFFC',
+        supportBorder: '#F6F3E1',
       },
       fontFamily: {
         sans: ['Inter', 'Helvetica', 'Arial', 'sans-serif'], // Minimalistic and clean font stack


### PR DESCRIPTION
## Summary
- lighten global styling and add support border color
- refresh metadata for SEO
- drop logo in header and use text brand name
- update layout and borders to match new palette

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d967bbf44832882d8532fb50b0eb9