### PR TITLE
Add top members dashboard and update post limits

### DIFF
--- a/server/routes/post.js
+++ b/server/routes/post.js
@@ -197,6 +197,9 @@ router.post("/:id/like", authenticateToken, async (req, res) => {
     post.likes.push(req.user._id);
     await post.save();
     await User.findByIdAndUpdate(req.user._id, { $inc: { rating: 1 } });
+    if (post.user && post.user.toString() !== req.user._id.toString()) {
+      await User.findByIdAndUpdate(post.user, { $inc: { rating: 1 } });
+    }
     await post.populate("likes", "username");
 
     res.json({ message: "Post liked", likesCount: post.likes.length, likes: post.likes });
@@ -276,7 +279,9 @@ router.post("/:id/share", authenticateToken, async (req, res) => {
     await post.save();
 
     await User.findByIdAndUpdate(req.user._id, { $inc: { rating: 1 } });
-
+    if (post.user && post.user.toString() !== req.user._id.toString()) {
+      await User.findByIdAndUpdate(post.user, { $inc: { rating: 1 } });
+    }
     res.json({ shares: post.shares });
   } catch (err) {
     console.error("Share error:", err);

--- a/src/app/components/LayoutClient.tsx
+++ b/src/app/components/LayoutClient.tsx
@@ -7,6 +7,7 @@ import { CartProvider } from "../context/CartContext";
 import { ThemeProvider } from "../context/ThemeContext";
 import Header from "./Header";
 import TrendingHashtags from "./TrendingHashtags";
+import TopActiveMembers from "./TopActiveMembers";
 import BottomNav from "./BottomNav";
 import SidebarControl from "./SidebarControl";
 import NavigationLoader from "./NavigationLoader";
@@ -91,37 +92,7 @@ export default function LayoutClient({ children }: { children: React.ReactNode }
                 className="hidden md:block w-full md:w-1/4 sticky top-16 h-[calc(100vh-80px)] overflow-y-auto p-2 fade-in-up"
               >
                 <div className="space-y-6">
-                  <div className="p-4 transition-shadow duration-200 hover:shadow-md">
-                    <h2 className="flex items-center font-semibold mb-3">
-                      <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        className="w-5 h-5 mr-2 text-brandCyan"
-                        fill="none"
-                        viewBox="0 0 24 24"
-                        stroke="currentColor"
-                      >
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M13 7h8m0 0v8m0-8l-8 8-4-4-6 6" />
-                      </svg>
-                      Идэвхтэй сэдвүүд
-                    </h2>
-                    <ul className="space-y-3">
-                      <li>
-                        <a href="#" className="text-brandCyan hover:underline transition-colors duration-200">
-                          #Инноваци
-                        </a>
-                      </li>
-                      <li>
-                        <a href="#" className="text-brandCyan hover:underline transition-colors duration-200">
-                          #Сүлжээ
-                        </a>
-                      </li>
-                      <li>
-                        <a href="#" className="text-brandCyan hover:underline transition-colors duration-200">
-                          #DAO
-                        </a>
-                      </li>
-                    </ul>
-                  </div>
+                  <TopActiveMembers />
                   <TrendingHashtags />
                 </div>
               </aside>

--- a/src/app/components/TopActiveMembers.tsx
+++ b/src/app/components/TopActiveMembers.tsx
@@ -1,0 +1,58 @@
+"use client";
+import { useEffect, useState } from "react";
+import axios from "axios";
+import { UserIcon } from "@heroicons/react/24/solid";
+
+interface Member {
+  _id: string;
+  username: string;
+  profilePicture?: string;
+  rating?: number;
+}
+
+const BASE_URL = "https://www.vone.mn";
+
+export default function TopActiveMembers() {
+  const [members, setMembers] = useState<Member[]>([]);
+
+  useEffect(() => {
+    const fetchMembers = async () => {
+      try {
+        const res = await axios.get<Member[]>(`${BASE_URL}/api/users`);
+        const sorted = res.data
+          .sort((a, b) => (b.rating || 0) - (a.rating || 0))
+          .slice(0, 3);
+        setMembers(sorted);
+      } catch (err) {
+        console.error(err);
+      }
+    };
+    fetchMembers();
+  }, []);
+
+  return (
+    <div className="p-4 transition-shadow duration-200 hover:shadow-md">
+      <h2 className="flex items-center font-semibold mb-3">
+        <UserIcon className="w-5 h-5 mr-2 text-brandCyan" />
+        Top Members
+      </h2>
+      <ul className="space-y-2 text-sm">
+        {members.map((m) => (
+          <li key={m._id} className="flex items-center gap-2">
+            {m.profilePicture ? (
+              <img
+                src={`${BASE_URL}${m.profilePicture}`}
+                alt={m.username}
+                className="w-8 h-8 rounded-full object-cover border border-brandCyan"
+              />
+            ) : (
+              <div className="w-8 h-8 rounded-full bg-gray-300 border border-brandCyan" />
+            )}
+            <span className="truncate">{m.username}</span>
+            <span className="ml-auto text-xs text-gray-500">{m.rating || 0}pt</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/app/new-post/page.tsx
+++ b/src/app/new-post/page.tsx
@@ -31,6 +31,10 @@ export default function NewPostPage() {
             setError("Контентыг бөглөнө үү");
             return;
         }
+        if (content.length > 500) {
+            setError("Хэт урт контент");
+            return;
+        }
         if (!user?.accessToken) {
             setError("Нэвтэрч ороогүй байна.");
             return;
@@ -55,7 +59,7 @@ export default function NewPostPage() {
     };
 
     return (
-        <div className="min-h-screen bg-gray-100 text-gray-900 p-4">
+        <div className="min-h-screen bg-white text-gray-900 p-4">
             <div className="max-w-xl mx-auto space-y-4">
                 <h1 className="text-xl font-bold">Create Post</h1>
                 <input
@@ -67,7 +71,7 @@ export default function NewPostPage() {
                 />
                 <button
                     onClick={triggerFileInput}
-                    className="p-2 border border-gray-200 rounded-full hover:bg-gray-100"
+                    className="p-2 border border-gray-200 rounded-full hover:bg-gray-200"
                 >
                     <FiCamera className="w-5 h-5 text-brandCyan" />
                 </button>
@@ -76,7 +80,7 @@ export default function NewPostPage() {
                         {imageFile.name}
                     </span>
                 )}
-                <textarea
+                <textarea maxLength={500}
                     placeholder="What's on your mind?"
                     className="w-full text-sm text-gray-900 border border-gray-200 rounded p-2 focus:outline-none"
                     rows={3}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -22,7 +22,6 @@ import {
 } from "@heroicons/react/24/outline";
 import { FiCamera } from "react-icons/fi";
 import LoadingSpinner from "./components/LoadingSpinner";
-import HomeSlider from "./components/HomeSlider";
 import { motion } from "framer-motion";
 import { formatPostDate } from "./lib/formatDate";
 import useCurrentLocation from "./hooks/useCurrentLocation";
@@ -228,6 +227,7 @@ export default function HomePage() {
   const createPost = async () => {
     setError("");
     if (!content.trim()) return setError("Контентыг бөглөнө үү");
+    if (content.length > 500) return setError("Хэт урт контент");
     if (!user?.accessToken) return setError("Нэвтэрч ороогүй байна.");
 
     try {
@@ -387,7 +387,7 @@ export default function HomePage() {
   // UI
   // ────────────────────────────────────────────────────────────
   return (
-    <div className="min-h-screen bg-gray-100 text-gray-900">
+    <div className="min-h-screen bg-white text-gray-900">
       {/* Membership banner */}
       {loggedIn && !isPro && (
         <div className="bg-yellow-500 text-white text-center py-2 px-4">
@@ -397,7 +397,6 @@ export default function HomePage() {
         </div>
       )}
 
-      <HomeSlider />
 
       {/* Outer grid */}
       <div
@@ -472,7 +471,7 @@ export default function HomePage() {
                 />
                 <button
                   onClick={triggerFileInput}
-                  className="p-2 border border-gray-200 rounded-full hover:bg-gray-100"
+                  className="p-2 border border-gray-200 rounded-full hover:bg-gray-200"
                 >
                   <FiCamera className="w-5 h-5 text-brandCyan" />
                 </button>
@@ -484,7 +483,7 @@ export default function HomePage() {
               </div>
 
 
-              <textarea
+              <textarea maxLength={500}
                 placeholder="What's on your mind?"
                 className="w-full text-sm text-gray-900 border border-gray-200 rounded p-2 focus:outline-none"
                 rows={3}


### PR DESCRIPTION
## Summary
- add TopActiveMembers component to show active users
- remove HomeSlider, tweak layout and backgrounds
- limit post length to 500 characters
- award points to post authors when their posts are liked or shared

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dd1240418832889402d21d51c1f43