### PR TITLE
Improve posting UX and remove location sort

### DIFF
--- a/src/app/components/AddPostModal.tsx
+++ b/src/app/components/AddPostModal.tsx
@@ -1,0 +1,132 @@
+import React, { useState, useRef } from "react";
+import Modal from "./Modal";
+import { FiCamera, FiX, FiSmile } from "react-icons/fi";
+import axios from "axios";
+import { useAuth } from "../context/AuthContext";
+
+const emojis = ["😀","😂","😍","😢","👍","🙏","🔥","🎉","🤔","🤩"];
+
+interface Props {
+  onClose: () => void;
+  onPost?: (post: any) => void;
+}
+
+export default function AddPostModal({ onClose, onPost }: Props) {
+  const { user } = useAuth();
+  const [content, setContent] = useState("");
+  const [imageFile, setImageFile] = useState<File | null>(null);
+  const [error, setError] = useState("");
+  const [showEmojis, setShowEmojis] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const MAX_LENGTH = 500;
+  const BASE_URL = "https://www.vone.mn";
+
+  const triggerFileInput = () => fileInputRef.current?.click();
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (e.target.files?.[0]) setImageFile(e.target.files[0]);
+  };
+  const removeImage = () => setImageFile(null);
+  const addEmoji = (emoji: string) => {
+    setContent((prev) => prev + emoji);
+    setShowEmojis(false);
+  };
+
+  const createPost = async () => {
+    setError("");
+    if (!content.trim()) return setError("Контентыг бөглөнө үү");
+    if (content.length > MAX_LENGTH) return setError("Хэт урт контент");
+    if (!user?.accessToken) return setError("Нэвтэрч ороогүй байна.");
+    try {
+      const formData = new FormData();
+      formData.append("content", content);
+      if (imageFile) formData.append("image", imageFile);
+      const { data } = await axios.post(`${BASE_URL}/api/posts`, formData, {
+        headers: {
+          Authorization: `Bearer ${user.accessToken}`,
+          "Content-Type": "multipart/form-data",
+        },
+      });
+      onPost?.(data.post);
+      setContent("");
+      setImageFile(null);
+      onClose();
+    } catch (err) {
+      console.error("Create post error:", err);
+      setError("Алдаа гарлаа");
+    }
+  };
+
+  return (
+    <Modal onClose={onClose}>
+      <div className="p-6 space-y-4">
+        <h2 className="text-lg font-semibold">Create Post</h2>
+        <input
+          type="file"
+          accept="image/*"
+          ref={fileInputRef}
+          onChange={handleFileChange}
+          className="hidden"
+        />
+        <div className="flex items-center gap-3 relative">
+          <button
+            onClick={triggerFileInput}
+            className="p-2 border border-gray-300 rounded-full"
+            aria-label="Add image"
+          >
+            <FiCamera className="w-5 h-5" />
+          </button>
+          <button
+            onClick={() => setShowEmojis((p) => !p)}
+            className="p-2 border border-gray-300 rounded-full"
+            aria-label="Add emoji"
+          >
+            <FiSmile className="w-5 h-5" />
+          </button>
+          {showEmojis && (
+            <div className="absolute top-full mt-2 left-0 bg-white border rounded shadow grid grid-cols-5 gap-1 p-2 z-10">
+              {emojis.map((e) => (
+                <button key={e} onClick={() => addEmoji(e)} className="text-xl">
+                  {e}
+                </button>
+              ))}
+            </div>
+          )}
+          {imageFile && (
+            <div className="relative w-full">
+              <img
+                src={URL.createObjectURL(imageFile)}
+                alt="preview"
+                className="h-32 w-full object-cover rounded-lg"
+              />
+              <button
+                type="button"
+                onClick={removeImage}
+                className="absolute top-1 right-1 bg-black/60 text-white p-1 rounded-full"
+              >
+                <FiX className="w-3 h-3" />
+              </button>
+            </div>
+          )}
+        </div>
+        <div className="relative">
+          <textarea
+            maxLength={MAX_LENGTH}
+            placeholder="What's happening?"
+            className="w-full bg-gray-100 text-sm text-gray-900 border border-gray-300 rounded-lg p-3 focus:outline-none resize-none"
+            rows={4}
+            value={content}
+            onChange={(e) => setContent(e.target.value)}
+          />
+          <span className={`absolute bottom-2 right-3 text-xs ${content.length > MAX_LENGTH * 0.9 ? "text-red-500" : "text-gray-400"}`}>{content.length}/{MAX_LENGTH}</span>
+        </div>
+        {error && <p className="text-red-500 text-sm">{error}</p>}
+        <button
+          onClick={createPost}
+          className="w-full bg-brandCyan text-black font-medium px-4 py-2 rounded-lg"
+        >
+          Post
+        </button>
+      </div>
+    </Modal>
+  );
+}

--- a/src/app/components/BottomNav.tsx
+++ b/src/app/components/BottomNav.tsx
@@ -4,14 +4,15 @@ import React, { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import {
     HomeIcon,
-    MagnifyingGlassIcon,
     PlusCircleIcon,
     BellIcon,
 } from "@heroicons/react/24/outline";
+import AddPostModal from "./AddPostModal";
 
 const BottomNav: React.FC = () => {
     const router = useRouter();
     const [scrolledDown, setScrolledDown] = useState(false);
+    const [showModal, setShowModal] = useState(false);
 
     useEffect(() => {
         let lastY = window.scrollY;
@@ -30,6 +31,7 @@ const BottomNav: React.FC = () => {
     }, []);
 
     return (
+        <>
         <nav
             className={`fixed bottom-0 left-0 w-full md:hidden transition-all backdrop-blur-xl border-t border-supportBorder shadow-lg ${
                 scrolledDown ? "bg-gradient-to-br from-white/40 via-white/20 to-white/10" : "bg-gradient-to-br from-white/30 via-white/10 to-white/5"
@@ -49,7 +51,7 @@ const BottomNav: React.FC = () => {
 
                 {/* NEW POST */}
                 <button
-                    onClick={() => router.push("/new-post")}
+                    onClick={() => setShowModal(true)}
                     aria-label="New Post"
                     className="p-1 text-black"
                 >
@@ -67,6 +69,16 @@ const BottomNav: React.FC = () => {
 
             </div>
         </nav>
+        {showModal && (
+            <AddPostModal
+                onClose={() => setShowModal(false)}
+                onPost={() => {
+                    setShowModal(false);
+                    router.refresh();
+                }}
+            />
+        )}
+        </>
     );
 };
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -20,11 +20,10 @@ import {
   ShareIcon,
   ArrowPathIcon,
 } from "@heroicons/react/24/outline";
-import { FiCamera } from "react-icons/fi";
+import { FiCamera, FiSmile } from "react-icons/fi";
 import LoadingSpinner from "./components/LoadingSpinner";
 import { motion } from "framer-motion";
 import { formatPostDate } from "./lib/formatDate";
-import useCurrentLocation from "./hooks/useCurrentLocation";
 
 // ────────────────────────────────────────────────────────────────
 // Types
@@ -78,6 +77,7 @@ export default function HomePage() {
   const [content, setContent] = useState("");
   const [imageFile, setImageFile] = useState<File | null>(null);
   const [error, setError] = useState("");
+  const [showEmojis, setShowEmojis] = useState(false);
   const [commentTexts, setCommentTexts] = useState<Record<string, string>>({});
   const [replyTexts, setReplyTexts] = useState<Record<string, string>>({});
   const [openComments, setOpenComments] = useState<Record<string, boolean>>({});
@@ -89,8 +89,8 @@ export default function HomePage() {
   const loadingPostsRef = useRef(false);
   const [refreshing, setRefreshing] = useState(false);
   const loadMoreRef = useRef<HTMLDivElement | null>(null);
+  const emojis = ["😀","😂","😍","😢","👍","🙏","🔥","🎉","🤔","🤩"];
 
-  const viewerCoords = useCurrentLocation();
   const isPro =
     user?.subscriptionExpiresAt &&
     new Date(user.subscriptionExpiresAt) > new Date();
@@ -105,7 +105,7 @@ export default function HomePage() {
   }, [loading, loggedIn, router]);
 
   // ────────────────────────────────────────────────────────────
-  // Fetch posts (location-aware smart sort)
+  // Fetch posts (latest first)
   // ────────────────────────────────────────────────────────────
   const fetchPosts = useCallback(
     async (page: number, append = false) => {
@@ -114,15 +114,9 @@ export default function HomePage() {
       setLoadingPosts(true);
       try {
         const params: Record<string, string | number> = {
-          sort: "smart",
           page,
           limit: 10,
         };
-        if (viewerCoords) {
-          params.currentLocation = `${viewerCoords.latitude},${viewerCoords.longitude}`;
-        } else if (user?.location) {
-          params.currentLocation = user.location;
-        }
         const { data } = await axios.get<Post[]>(`${BASE_URL}/api/posts`, {
           params,
         });
@@ -148,7 +142,7 @@ export default function HomePage() {
         loadingPostsRef.current = false;
       }
     },
-    [user, viewerCoords]
+    [user]
   );
 
   useEffect(() => {
@@ -394,7 +388,7 @@ export default function HomePage() {
           {loggedIn && (
             <div className="bg-white grid gap-4 p-6">
               {/* Upload */}
-              <div className="grid grid-cols-[auto,1fr] items-center gap-2">
+              <div className="grid grid-cols-[auto,auto,1fr] items-center gap-2 relative">
                 <input
                   type="file"
                   accept="image/*"
@@ -408,6 +402,21 @@ export default function HomePage() {
                 >
                   <FiCamera className="w-5 h-5 text-brandCyan" />
                 </button>
+                <button
+                  onClick={() => setShowEmojis((p) => !p)}
+                  className="p-2 border border-gray-200 rounded-full hover:bg-gray-200"
+                >
+                  <FiSmile className="w-5 h-5 text-brandCyan" />
+                </button>
+                {showEmojis && (
+                  <div className="absolute left-0 top-full mt-2 bg-white border rounded shadow grid grid-cols-5 gap-1 p-2 z-10">
+                    {emojis.map((e) => (
+                      <button key={e} onClick={() => setContent((c) => c + e)} className="text-xl">
+                        {e}
+                      </button>
+                    ))}
+                  </div>
+                )}
                 {imageFile && (
                   <span className="text-xs text-gray-700 truncate">
                     {imageFile.name}


### PR DESCRIPTION
## Summary
- create `AddPostModal` for inline post creation
- open the modal from the mobile bottom nav instead of redirecting
- allow emojis when creating posts on the feed and in the modal
- simplify post fetch algorithm to show latest posts without location

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684de00ff2248328a9ac60688945cac3