### PR TITLE
Add basic 3D mining game page

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,11 @@
     "slick-carousel": "^1.8.1",
     "stripe": "^17.5.0",
     "swiper": "^11.1.15",
-    "tailwind-scrollbar-hide": "^2.0.0"
+    "tailwind-scrollbar-hide": "^2.0.0",
+    "three": "^0.161.0",
+    "@react-three/fiber": "^8.13.5",
+    "@react-three/drei": "^9.90.1",
+    "zustand": "^4.4.1"
   },
   "devDependencies": {
     "@types/bcryptjs": "^2.4.6",

--- a/src/app/game/layout.tsx
+++ b/src/app/game/layout.tsx
@@ -1,0 +1,12 @@
+import "../globals.css";
+import { Inter } from "next/font/google";
+
+const inter = Inter({ subsets: ["latin"] });
+
+export default function GameLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body className={`${inter.className} bg-neutral-900`}>{children}</body>
+    </html>
+  );
+}

--- a/src/app/game/page.tsx
+++ b/src/app/game/page.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { Canvas } from "@react-three/fiber";
+import { OrbitControls, Stats } from "@react-three/drei";
+import { Suspense, useMemo } from "react";
+import create from "zustand";
+
+// -------- Zustand store --------
+interface GameState {
+  coins: number;
+  ore: number;
+  stock: number[];
+  mine: (id: number) => void;
+}
+
+const useGame = create<GameState>((set) => ({
+  coins: 0,
+  ore: 0,
+  stock: Array.from({ length: 100 }, (_, i) => i),
+  mine: (blockId: number) =>
+    set((s) => ({
+      ore: s.ore + 1,
+      coins: s.coins + 5,
+      stock: s.stock.filter((id) => id !== blockId),
+    })),
+}));
+
+// -------- Components --------
+interface OreBlockProps {
+  id: number;
+  position: [number, number, number];
+}
+
+function OreBlock({ id, position }: OreBlockProps) {
+  const mine = useGame((s) => s.mine);
+  return (
+    <mesh
+      position={position}
+      onClick={(e) => {
+        e.stopPropagation();
+        mine(id);
+      }}
+    >
+      <boxGeometry args={[1, 1, 1]} />
+      <meshStandardMaterial color="#ffd700" />
+    </mesh>
+  );
+}
+
+function World() {
+  const stock = useGame((s) => s.stock);
+  const blocks = useMemo(
+    () =>
+      stock.map((id) => {
+        const x = id % 10;
+        const z = Math.floor(id / 10);
+        return <OreBlock key={id} id={id} position={[x - 5, 0.5, z - 5]} />;
+      }),
+    [stock]
+  );
+  return (
+    <>
+      <mesh rotation={[-Math.PI / 2, 0, 0]}>
+        <planeGeometry args={[50, 50]} />
+        <meshStandardMaterial color="#333" />
+      </mesh>
+      {blocks}
+      <ambientLight intensity={0.4} />
+      <directionalLight position={[5, 10, 5]} intensity={0.8} />
+    </>
+  );
+}
+
+function HUD() {
+  const coins = useGame((s) => s.coins);
+  const ore = useGame((s) => s.ore);
+  return (
+    <div className="absolute top-4 left-4 bg-neutral-900/80 p-4 rounded-xl shadow text-cyan-300 space-y-1 text-sm">
+      <div>💰 Coins: {coins}</div>
+      <div>⛏️ Ore: {ore}</div>
+      <div className="text-neutral-400">Click gold blocks to mine → earn coins</div>
+    </div>
+  );
+}
+
+export default function GamePage() {
+  return (
+    <div className="w-screen h-screen bg-neutral-900">
+      <Canvas camera={{ position: [0, 15, 15], fov: 50 }} shadows>
+        <Suspense fallback={null}>
+          <World />
+          <OrbitControls enablePan={false} />
+          <Stats />
+        </Suspense>
+      </Canvas>
+      <HUD />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- install three.js/react-three-fiber/drei/zustand dependencies
- add `/game` route with simple mining demo using react-three-fiber
- provide isolated layout for the game page

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684de1d2ea708328a5dd8d9fbcfd7b53