### PR TITLE
Fix dynamic import alias in game page

### DIFF
--- a/src/app/game/page.tsx
+++ b/src/app/game/page.tsx
@@ -2,9 +2,9 @@
 
 export const dynamic = "force-dynamic";
 
-import dynamic from "next/dynamic";
+import dynamicImport from "next/dynamic";
 
-const GameClient = dynamic(() => import("./GameClient"), { ssr: false });
+const GameClient = dynamicImport(() => import("./GameClient"), { ssr: false });
 
 export default function GamePage() {
   return <GameClient />;


### PR DESCRIPTION
## Summary
- avoid naming conflict with `dynamic` export by aliasing the `next/dynamic` import

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684de98fba9483288ece8b5507da8ce3