### PR TITLE
Fix /game route and improve game interface

### DIFF
--- a/src/app/components/LayoutClient.tsx
+++ b/src/app/components/LayoutClient.tsx
@@ -16,11 +16,22 @@ import Link from "next/link";
 export default function LayoutClient({ children }: { children: React.ReactNode }) {
   const [mountLoading, setMountLoading] = useState(true);
   const pathname = usePathname();
+  const isGameRoute = pathname === "/game";
 
   useEffect(() => {
     const timer = setTimeout(() => setMountLoading(false), 500);
     return () => clearTimeout(timer);
   }, []);
+
+  if (isGameRoute) {
+    return (
+      <ThemeProvider>
+        <CartProvider>
+          <AuthProvider>{children}</AuthProvider>
+        </CartProvider>
+      </ThemeProvider>
+    );
+  }
 
   return (
     <ThemeProvider>

--- a/src/app/game/GameClient.tsx
+++ b/src/app/game/GameClient.tsx
@@ -11,6 +11,7 @@ interface GameState {
   ore: number;
   stock: number[];
   mine: (id: number) => void;
+  reset: () => void;
 }
 
 const useGame = create<GameState>((set) => ({
@@ -22,6 +23,12 @@ const useGame = create<GameState>((set) => ({
       ore: s.ore + 1,
       coins: s.coins + 5,
       stock: s.stock.filter((id) => id !== blockId),
+    })),
+  reset: () =>
+    set(() => ({
+      coins: 0,
+      ore: 0,
+      stock: Array.from({ length: 100 }, (_, i) => i),
     })),
 }));
 
@@ -74,11 +81,19 @@ function World() {
 function HUD() {
   const coins = useGame((s) => s.coins);
   const ore = useGame((s) => s.ore);
+  const stock = useGame((s) => s.stock);
+  const reset = useGame((s) => s.reset);
   return (
     <div className="absolute top-4 left-4 bg-neutral-900/80 p-4 rounded-xl shadow text-cyan-300 space-y-1 text-sm">
       <div>💰 Coins: {coins}</div>
       <div>⛏️ Ore: {ore}</div>
+      {stock.length === 0 && (
+        <div className="text-green-400">All ore mined!</div>
+      )}
       <div className="text-neutral-400">Click gold blocks to mine → earn coins</div>
+      <button onClick={reset} className="mt-1 px-2 py-1 bg-cyan-700 rounded text-white">
+        Reset Game
+      </button>
     </div>
   );
 }

--- a/src/app/game/layout.tsx
+++ b/src/app/game/layout.tsx
@@ -1,12 +1,6 @@
 import "../globals.css";
-import { Inter } from "next/font/google";
 
-const inter = Inter({ subsets: ["latin"] });
-
+// Simplified layout to avoid nested <html> elements
 export default function GameLayout({ children }: { children: React.ReactNode }) {
-  return (
-    <html lang="en">
-      <body className={`${inter.className} bg-neutral-900`}>{children}</body>
-    </html>
-  );
+  return <>{children}</>;
 }

--- a/src/app/game/page.tsx
+++ b/src/app/game/page.tsx
@@ -1,10 +1,6 @@
 "use client";
 
-export const dynamic = "force-dynamic";
-
-import dynamicImport from "next/dynamic";
-
-const GameClient = dynamicImport(() => import("./GameClient"), { ssr: false });
+import GameClient from "./GameClient";
 
 export default function GamePage() {
   return <GameClient />;


### PR DESCRIPTION
## Summary
- simplify the `game` layout to prevent nested `<html>` tags
- skip global layout elements on `/game` to avoid client errors
- tweak game store and HUD: allow resetting and show completion message
- replace dynamic import with direct client component import

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684deb37ed788328bbabdd58d2faf7cb