### PR TITLE
Fix prerender crash on /game

### DIFF
--- a/src/app/game/page.tsx
+++ b/src/app/game/page.tsx
@@ -2,6 +2,11 @@
 
 import GameClient from "./GameClient";
 
+// Disable static rendering for this page since the Three.js based
+// components rely on browser APIs that are not available during
+// Next.js' build-time prerendering phase.
+export const dynamic = "force-dynamic";
+
 export default function GamePage() {
   return <GameClient />;
 }


### PR DESCRIPTION
## Summary
- disable SSG for the `/game` page by exporting `dynamic = "force-dynamic"`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dedd0a240832899d750f7ff69e7ac