### PR TITLE
Fix GamePage prerender error

### DIFF
--- a/src/app/game/page.tsx
+++ b/src/app/game/page.tsx
@@ -1,6 +1,9 @@
-"use client";
+import dynamic from "next/dynamic";
 
-import GameClient from "./GameClient";
+// Dynamically import the client component so it is never
+// executed on the server during prerendering. This avoids
+// errors from libraries that depend on browser-only APIs.
+const GameClient = dynamic(() => import("./GameClient"), { ssr: false });
 
 // Disable static rendering for this page since the Three.js based
 // components rely on browser APIs that are not available during


### PR DESCRIPTION
## Summary
- use `next/dynamic` to avoid SSR for GameClient

## Testing
- `npm test` *(fails: jest not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684df38f2b44832899164ec4fa5a96b4