### PR TITLE
Fix dynamic import alias

### DIFF
--- a/src/app/game/page.tsx
+++ b/src/app/game/page.tsx
@@ -1,9 +1,9 @@
-import dynamic from "next/dynamic";
+import dynamicImport from "next/dynamic";
 
 // Dynamically import the client component so it is never
 // executed on the server during prerendering. This avoids
 // errors from libraries that depend on browser-only APIs.
-const GameClient = dynamic(() => import("./GameClient"), { ssr: false });
+const GameClient = dynamicImport(() => import("./GameClient"), { ssr: false });
 
 // Disable static rendering for this page since the Three.js based
 // components rely on browser APIs that are not available during


### PR DESCRIPTION
## Summary
- use an alias when importing `next/dynamic`
- update the call to `dynamic` accordingly

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684df5b03774832884158917d8000e15