### PR TITLE
Add Classroom page and navigation

### DIFF
--- a/src/app/classroom/page.tsx
+++ b/src/app/classroom/page.tsx
@@ -1,0 +1,170 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { CheckIcon } from '@heroicons/react/24/outline';
+import { AcademicCapIcon } from '@heroicons/react/24/solid';
+
+interface Lesson {
+  id: number;
+  url: string;
+  title: string;
+  description?: string;
+  duration?: string;
+  completed: boolean;
+}
+
+const isAdmin = true;
+
+function extractVideoId(url: string) {
+  const regex = /(?:youtube\.com\/(?:[^\/\n\s]+\/\S+\/|(?:v|e(?:mbed)?|shorts)\/|.*[?&]v=)|youtu\.be\/)([A-Za-z0-9_-]{11})/;
+  const match = url.match(regex);
+  return match ? match[1] : '';
+}
+
+export default function ClassroomPage() {
+  const [lessons, setLessons] = useState<Lesson[]>([]);
+  const [selected, setSelected] = useState<Lesson | null>(null);
+  const [newTitle, setNewTitle] = useState('');
+  const [newUrl, setNewUrl] = useState('');
+  const [newDesc, setNewDesc] = useState('');
+
+  useEffect(() => {
+    const stored = localStorage.getItem('lessons');
+    if (stored) {
+      try {
+        const parsed = JSON.parse(stored) as Lesson[];
+        setLessons(parsed);
+        if (parsed.length) setSelected(parsed[0]);
+      } catch {}
+    }
+  }, []);
+
+  useEffect(() => {
+    if (lessons.length) {
+      localStorage.setItem('lessons', JSON.stringify(lessons));
+    }
+  }, [lessons]);
+
+  const addLesson = () => {
+    const id = Date.now();
+    const newLesson: Lesson = {
+      id,
+      url: newUrl,
+      title: newTitle,
+      description: newDesc,
+      completed: false,
+    };
+    setLessons((prev) => [...prev, newLesson]);
+    setNewTitle('');
+    setNewUrl('');
+    setNewDesc('');
+    if (!selected) setSelected(newLesson);
+  };
+
+  const toggleCompleted = (id: number) => {
+    setLessons((prev) =>
+      prev.map((l) => (l.id === id ? { ...l, completed: !l.completed } : l))
+    );
+  };
+
+  const progress = lessons.length
+    ? Math.round(
+        (lessons.filter((l) => l.completed).length / lessons.length) * 100
+      )
+    : 0;
+
+  return (
+    <div className="flex flex-col md:flex-row min-h-screen">
+      <div className="w-full md:w-80 border-r p-4 bg-white dark:bg-gray-800">
+        <h2 className="text-xl font-bold mb-4 flex items-center gap-2">
+          <AcademicCapIcon className="w-6 h-6" /> Classroom
+        </h2>
+        <div className="flex items-center mb-2">
+          <div className="flex-1 h-2 bg-gray-200 rounded">
+            <div
+              className="h-full bg-green-400 rounded"
+              style={{ width: `${progress}%` }}
+            />
+          </div>
+          <span className="ml-2 text-green-600 font-medium">{progress}%</span>
+        </div>
+        <ul>
+          {lessons.map((lesson) => (
+            <li
+              key={lesson.id}
+              className={`flex items-center px-3 py-2 rounded cursor-pointer mb-1 ${lesson.completed ? 'bg-green-50' : 'bg-yellow-50'} ${selected && selected.id === lesson.id ? 'border-l-4 border-cyan-400 bg-cyan-50' : ''}`}
+              onClick={() => setSelected(lesson)}
+            >
+              <CheckIcon
+                className={`w-5 h-5 mr-2 ${lesson.completed ? 'text-green-500' : 'text-gray-400'}`}
+              />
+              <span className="font-medium flex-1 truncate">{lesson.title}</span>
+              <input
+                type="checkbox"
+                checked={lesson.completed}
+                onChange={() => toggleCompleted(lesson.id)}
+                className="ml-2"
+              />
+            </li>
+          ))}
+        </ul>
+        {isAdmin && (
+          <div className="mt-4 space-y-2">
+            <input
+              type="text"
+              placeholder="YouTube URL"
+              value={newUrl}
+              onChange={(e) => setNewUrl(e.target.value)}
+              className="w-full border p-1 rounded"
+            />
+            <input
+              type="text"
+              placeholder="Title"
+              value={newTitle}
+              onChange={(e) => setNewTitle(e.target.value)}
+              className="w-full border p-1 rounded"
+            />
+            <textarea
+              placeholder="Description"
+              value={newDesc}
+              onChange={(e) => setNewDesc(e.target.value)}
+              className="w-full border p-1 rounded"
+            />
+            <button
+              onClick={addLesson}
+              className="w-full bg-brandCyan text-black py-1 rounded"
+            >
+              Add Lesson
+            </button>
+          </div>
+        )}
+      </div>
+      <div className="flex-1 p-8 bg-gray-50 dark:bg-gray-900">
+        {selected ? (
+          <>
+            <h1 className="text-2xl font-bold mb-3">{selected.title}</h1>
+            <iframe
+              width="100%"
+              height="400"
+              src={`https://www.youtube.com/embed/${extractVideoId(selected.url)}`}
+              allowFullScreen
+              className="rounded-xl border mb-4"
+            />
+            {selected.description && (
+              <p className="text-lg text-gray-700 dark:text-gray-300">
+                {selected.description}
+              </p>
+            )}
+            {selected.duration && (
+              <div className="mt-4 text-sm text-gray-400">
+                Duration: {selected.duration}
+              </div>
+            )}
+          </>
+        ) : (
+          <p className="text-center text-gray-500">Select a lesson</p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/components/BottomNav.tsx
+++ b/src/app/components/BottomNav.tsx
@@ -6,6 +6,7 @@ import {
     HomeIcon,
     PlusCircleIcon,
     BellIcon,
+    AcademicCapIcon,
 } from "@heroicons/react/24/outline";
 import AddPostModal from "./AddPostModal";
 
@@ -65,6 +66,15 @@ const BottomNav: React.FC = () => {
                     className="p-1 text-black"
                 >
                     <BellIcon className="h-7 w-7" />
+                </button>
+
+                {/* CLASSROOM */}
+                <button
+                    onClick={() => router.push("/classroom")}
+                    aria-label="Classroom"
+                    className="p-1 text-black"
+                >
+                    <AcademicCapIcon className="h-7 w-7" />
                 </button>
 
             </div>

--- a/src/app/components/Header.tsx
+++ b/src/app/components/Header.tsx
@@ -257,6 +257,29 @@ export default function Header() {
                                             Гишүүд
                                         </Link>
                                     </li>
+                                    <li>
+                                        <Link
+                                            href="/classroom"
+                                            onClick={() => setIsMenuOpen(false)}
+                                            className="flex items-center gap-2 hover:text-brandCyan"
+                                        >
+                                            <svg
+                                                xmlns="http://www.w3.org/2000/svg"
+                                                className="w-6 h-6"
+                                                fill="none"
+                                                viewBox="0 0 24 24"
+                                                stroke="currentColor"
+                                            >
+                                                <path
+                                                    strokeLinecap="round"
+                                                    strokeLinejoin="round"
+                                                    strokeWidth="2"
+                                                    d="M12 14l9-5-9-5-9 5 9 5zm0 0v6"
+                                                />
+                                            </svg>
+                                            Classroom
+                                        </Link>
+                                    </li>
                                 </ul>
                             </div>
                         </nav>

--- a/src/app/components/LayoutClient.tsx
+++ b/src/app/components/LayoutClient.tsx
@@ -64,23 +64,40 @@ export default function LayoutClient({ children }: { children: React.ReactNode }
                         <span>Нүүр</span>
                       </Link>
                     </li>
-                    <li>
-                      <Link
-                        href="/users"
-                        className="group flex items-center gap-2 p-4 pl-0 text-xl font-semibold text-gray-700 transition-smooth focus:outline-none hover:text-brandCyan focus:ring-2 focus:ring-brandCyan"
+                  <li>
+                    <Link
+                      href="/users"
+                      className="group flex items-center gap-2 p-4 pl-0 text-xl font-semibold text-gray-700 transition-smooth focus:outline-none hover:text-brandCyan focus:ring-2 focus:ring-brandCyan"
+                    >
+                      <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        className="w-6 h-6 group-hover:text-brandCyan"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
                       >
-                        <svg
-                          xmlns="http://www.w3.org/2000/svg"
-                          className="w-6 h-6 group-hover:text-brandCyan"
-                          fill="none"
-                          viewBox="0 0 24 24"
-                          stroke="currentColor"
-                        >
-                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
-                        </svg>
-                        <span>Гишүүд</span>
-                      </Link>
-                    </li>
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
+                      </svg>
+                      <span>Гишүүд</span>
+                    </Link>
+                  </li>
+                  <li>
+                    <Link
+                      href="/classroom"
+                      className="group flex items-center gap-2 p-4 pl-0 text-xl font-semibold text-gray-700 transition-smooth focus:outline-none hover:text-brandCyan focus:ring-2 focus:ring-brandCyan"
+                    >
+                      <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        className="w-6 h-6 group-hover:text-brandCyan"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                      >
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 14l9-5-9-5-9 5 9 5zm0 0v6" />
+                      </svg>
+                      <span>Classroom</span>
+                    </Link>
+                  </li>
                   </ul>
                 </nav>
               </aside>

--- a/src/app/components/SidebarControl.tsx
+++ b/src/app/components/SidebarControl.tsx
@@ -8,7 +8,7 @@ export default function SidebarControl() {
     const left = document.getElementById('left-sidebar');
     const right = document.getElementById('right-sidebar');
     if (!left || !right) return;
-    if (pathname.startsWith('/dashboard')) {
+    if (pathname.startsWith('/dashboard') || pathname.startsWith('/classroom')) {
       left.style.display = 'none';
       right.style.display = 'none';
     } else {


### PR DESCRIPTION
## Summary
- add `/classroom` page with YouTube lessons and progress tracking
- add Classroom link in sidebar, header menu, and mobile nav
- hide global sidebars for classroom route

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e59a498288328bbb6cf7257536341