### PR TITLE
Implement post deletion and UI updates

### DIFF
--- a/src/app/components/PostCard.tsx
+++ b/src/app/components/PostCard.tsx
@@ -1,8 +1,12 @@
 "use client";
 import React, { useState } from "react";
+import { motion } from "framer-motion";
 import { FaCheckCircle } from "react-icons/fa";
 import { BoltIcon, HeartIcon as HeartSolid } from "@heroicons/react/24/solid";
-import { HeartIcon as HeartOutline, ShareIcon } from "@heroicons/react/24/outline";
+import {
+  HeartIcon as HeartOutline,
+  ArrowUpTrayIcon,
+} from "@heroicons/react/24/outline";
 import { formatPostDate } from "../lib/formatDate";
 import { useAuth } from "../context/AuthContext";
 import axios from "axios";
@@ -28,12 +32,13 @@ interface Post {
 interface Props {
   post: Post;
   user: User;
+  onDelete?: (id: string) => void;
 }
 
 const BASE_URL = "https://www.vone.mn";
 const UPLOADS_URL = `${BASE_URL}/api/uploads`;
 
-export default function PostCard({ post, user }: Props) {
+export default function PostCard({ post, user, onDelete }: Props) {
   const { user: viewer, login } = useAuth();
   const isPro = user.subscriptionExpiresAt
     ? new Date(user.subscriptionExpiresAt) > new Date()
@@ -77,6 +82,18 @@ export default function PostCard({ post, user }: Props) {
       console.error("Share error:", err);
     }
   };
+
+  const handleDelete = async () => {
+    if (!viewer?.accessToken) return;
+    try {
+      await axios.delete(`${BASE_URL}/api/posts/${post._id}`, {
+        headers: { Authorization: `Bearer ${viewer.accessToken}` },
+      });
+      onDelete?.(post._id);
+    } catch (err) {
+      console.error("Delete error:", err);
+    }
+  };
   return (
     <div className="bg-white p-6 grid gap-4 border-b border-gray-200">
       <div className="flex gap-3 group">
@@ -97,6 +114,14 @@ export default function PostCard({ post, user }: Props) {
               {formatPostDate(post.createdAt)}
             </span>
             <BoltIcon className="w-3 h-3 text-green-400 ml-1" />
+            {viewerId === post.user?._id && (
+              <button
+                onClick={handleDelete}
+                className="ml-auto text-red-500 text-xs"
+              >
+                Delete
+              </button>
+            )}
           </div>
           <div className="relative">
             {post.content && (
@@ -113,7 +138,8 @@ export default function PostCard({ post, user }: Props) {
             )}
           </div>
           <div className="grid grid-cols-3 items-center text-gray-500 text-xs mt-3">
-            <button
+            <motion.button
+              whileTap={{ scale: 0.8 }}
               onClick={handleLike}
               className="flex items-center justify-center gap-1 hover:text-gray-700"
               aria-label="Like"
@@ -124,16 +150,17 @@ export default function PostCard({ post, user }: Props) {
                 <HeartOutline className="w-4 h-4" />
               )}
               <span>{likes}</span>
-            </button>
+            </motion.button>
             <span className="text-center">{post.comments?.length || 0} Comments</span>
-            <button
+            <motion.button
+              whileTap={{ scale: 0.8 }}
               onClick={handleShare}
               className="flex items-center justify-center gap-1 hover:text-gray-700"
               aria-label="Share"
             >
-              <ShareIcon className={shared ? "w-4 h-4 text-green-500" : "w-4 h-4"} />
+              <ArrowUpTrayIcon className={shared ? "w-4 h-4 text-green-500" : "w-4 h-4"} />
               <span>{shares}</span>
-            </button>
+            </motion.button>
           </div>
         </div>
       </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -16,7 +16,7 @@ import {
 import {
   HeartIcon as HeartOutline,
   ChatBubbleOvalLeftIcon,
-  ShareIcon,
+  ArrowUpTrayIcon,
   ArrowPathIcon,
 } from "@heroicons/react/24/outline";
 import LoadingSpinner from "./components/LoadingSpinner";
@@ -263,6 +263,18 @@ export default function HomePage() {
     }
   };
 
+  const handleDelete = async (postId: string) => {
+    if (!user?.accessToken) return;
+    try {
+      await axios.delete(`${BASE_URL}/api/posts/${postId}`, {
+        headers: { Authorization: `Bearer ${user.accessToken}` },
+      });
+      setPosts((prev) => prev.filter((p) => p._id !== postId));
+    } catch (err) {
+      console.error("Delete error:", err);
+    }
+  };
+
 
   const handleFollow = async (targetId: string) => {
     if (!user?.accessToken) return;
@@ -347,25 +359,35 @@ export default function HomePage() {
             </div>
           )}
 
-          {/* Create post */}
-          {loggedIn && <PostInput onPost={refreshPosts} />}
+          {/* Subscription gate */}
+          {loggedIn && !isPro ? (
+            <div className="bg-white p-6 text-center space-y-3">
+              <p>Feed үзэхийн тулд гишүүнчлэл идэвхжүүлнэ үү.</p>
+              <Link href="/subscription" className="text-blue-600 underline">
+                Subscribe
+              </Link>
+            </div>
+          ) : (
+            <>
+              {/* Create post */}
+              {loggedIn && <PostInput onPost={refreshPosts} />}
 
-          <div className="flex justify-end p-4">
-            <button
-              onClick={refreshPosts}
-              aria-label="Refresh feed"
-              className={`p-2 rounded-full hover:bg-gray-200 ${refreshing ? "animate-spin" : ""}`}
-            >
-              <ArrowPathIcon className="w-5 h-5" />
-            </button>
-          </div>
+              <div className="flex justify-end p-4">
+                <button
+                  onClick={refreshPosts}
+                  aria-label="Refresh feed"
+                  className={`p-2 rounded-full hover:bg-gray-200 ${refreshing ? "animate-spin" : ""}`}
+                >
+                  <ArrowPathIcon className="w-5 h-5" />
+                </button>
+              </div>
 
-          {/* Posts list */}
-          <div className="m-0 p-0">
-          {loadingPosts && pageNum === 1 ? (
-              <LoadingSpinner />
-            ) : (
-              posts.map((post, idx) => {
+              {/* Posts list */}
+              <div className="m-0 p-0">
+              {loadingPosts && pageNum === 1 ? (
+                  <LoadingSpinner />
+                ) : (
+                  posts.map((post, idx) => {
                 const postUser = post.user;
 
                 return (
@@ -420,6 +442,14 @@ export default function HomePage() {
                               )}
                             </div>
                           )}
+                          {postUser && user && user._id === postUser._id && (
+                            <button
+                              onClick={() => handleDelete(post._id)}
+                              className="text-red-500 text-xs ml-auto"
+                            >
+                              Delete
+                            </button>
+                          )}
                         </div>
 
                         <span className="text-xs text-gray-500">
@@ -449,7 +479,8 @@ export default function HomePage() {
                     {/* Actions */}
                     <div className="grid grid-cols-3 items-center text-xs text-gray-600 w-full mt-2">
                       {/* Like */}
-                      <button
+                      <motion.button
+                        whileTap={{ scale: 0.8 }}
                         onClick={() => handleLike(post._id)}
                         disabled={!loggedIn}
                         className="flex items-center justify-center gap-1 hover:text-gray-800"
@@ -461,7 +492,7 @@ export default function HomePage() {
                           <HeartOutline className="w-4 h-4" />
                         )}
                         <span>{post.likes.length}</span>
-                      </button>
+                      </motion.button>
 
                       {/* Comment */}
                       <button
@@ -475,19 +506,20 @@ export default function HomePage() {
                       </button>
 
                       {/* Share */}
-                      <button
+                      <motion.button
+                        whileTap={{ scale: 0.8 }}
                         onClick={() => handleShare(post._id)}
                         disabled={!loggedIn}
                         className="flex items-center justify-center gap-1 hover:text-gray-800"
                         aria-label={`Share (${post.shares || 0})`}
                       >
-                        <ShareIcon
+                        <ArrowUpTrayIcon
                           className={`w-4 h-4 ${
                             sharedPosts.includes(post._id) ? "text-green-500" : ""
                           }`}
                         />
                         <span>{post.shares || 0}</span>
-                      </button>
+                      </motion.button>
                     </div>
 
                     {/* Comment section */}
@@ -587,6 +619,8 @@ export default function HomePage() {
             {loadingPosts && pageNum > 1 && <LoadingSpinner />}
             <div ref={loadMoreRef} />
           </div>
+            </>
+        )}
         </main>
       </div>
     </div>

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -37,6 +37,19 @@ export default function MyOwnProfilePage() {
     const [loadingPosts, setLoadingPosts] = useState(false);
     const [error, setError] = useState("");
 
+    const handleDelete = async (postId: string) => {
+        const token = getToken();
+        if (!token) return;
+        try {
+            await axios.delete(`${BASE_URL}/api/posts/${postId}`, {
+                headers: { Authorization: `Bearer ${token}` },
+            });
+            setUserPosts((prev) => prev.filter((p) => p._id !== postId));
+        } catch (err) {
+            console.error("Delete post error:", err);
+        }
+    };
+
     const BASE_URL = "https://www.vone.mn";
     const UPLOADS_URL = `${BASE_URL}/api/uploads`;
 
@@ -180,7 +193,12 @@ export default function MyOwnProfilePage() {
                 ) : userPosts.length > 0 ? (
                     <div className="space-y-4">
                         {userPosts.map((post) => (
-                            <PostCard key={post._id} post={post} user={userData} />
+                            <PostCard
+                                key={post._id}
+                                post={post}
+                                user={userData}
+                                onDelete={handleDelete}
+                            />
                         ))}
                     </div>
                 ) : (


### PR DESCRIPTION
## Summary
- enforce 500 character limit when creating posts
- add API route to delete posts
- animate like/share buttons and update share icon
- allow deleting own posts from feed and profile pages
- gate feed access for non-subscribers

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685489f6bb1c8328a61b1a1f9ef7c925