### PR TITLE
Improve post interactions and mobile classroom

### DIFF
--- a/server/models/Post.js
+++ b/server/models/Post.js
@@ -17,6 +17,8 @@ const CommentSchema = new Schema({
 const PostSchema = new Schema(
     {
         user: { type: mongoose.Schema.Types.ObjectId, ref: "User", required: true },
+        // If this is a shared post, reference the original post
+        sharedFrom: { type: mongoose.Schema.Types.ObjectId, ref: "Post" },
         content: { type: String, required: true },
         image: { type: String }, // stores just the filename, e.g., "123456789-image.png"
         likes: [{ type: mongoose.Schema.Types.ObjectId, ref: "User" }],

--- a/src/app/classroom/page.tsx
+++ b/src/app/classroom/page.tsx
@@ -108,8 +108,8 @@ export default function ClassroomPage() {
     : 0;
 
   return (
-    <div className="flex h-full w-full min-h-screen">
-      <aside className="w-80 min-w-64 bg-white p-6 flex flex-col border-r border-gray-200 text-black">
+    <div className="flex flex-col md:flex-row h-full w-full min-h-screen">
+      <aside className="w-full md:w-80 md:min-w-64 bg-white p-6 flex flex-col border-b md:border-b-0 md:border-r border-gray-200 text-black">
         <h2 className="text-xl font-bold mb-4 flex items-center gap-2">
           <AcademicCapIcon className="w-6 h-6" /> Classroom
         </h2>
@@ -204,7 +204,7 @@ export default function ClassroomPage() {
           </div>
         )}
       </aside>
-      <main className="flex-1 bg-white p-10 flex flex-col text-black">
+      <main className="flex-1 bg-white p-4 md:p-10 flex flex-col text-black">
         {selected ? (
           <>
             <h1 className="text-2xl font-bold mb-3">{selected.title}</h1>

--- a/src/app/profile/[id]/page.tsx
+++ b/src/app/profile/[id]/page.tsx
@@ -30,6 +30,7 @@ interface PostData {
     title: string;
     content: string;
     createdAt: string;
+    sharedFrom?: PostData;
     image?: string;
     likes?: string[];
     comments?: any[];

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -23,6 +23,7 @@ interface PostData {
     title: string;
     content: string;
     createdAt: string;
+    sharedFrom?: PostData;
     image?: string;
     likes?: string[];
     comments?: any[];


### PR DESCRIPTION
## Summary
- support shared posts by referencing original post in DB
- allow editing posts via new API endpoint
- show options menu for posts with edit/delete actions
- render shared posts in feed and profile
- make classroom layout responsive on mobile

## Testing
- `npm run lint` *(fails: next not found)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68548f00a1b08328ab1d2de02eb960f9