### PR TITLE
Fix sharing posts visibility and mobile classroom

### DIFF
--- a/src/app/classroom/page.tsx
+++ b/src/app/classroom/page.tsx
@@ -109,7 +109,7 @@ export default function ClassroomPage() {
 
   return (
     <div className="flex flex-col md:flex-row h-full w-full min-h-screen">
-      <aside className="w-full md:w-80 md:min-w-64 bg-white p-6 flex flex-col border-b md:border-b-0 md:border-r border-gray-200 text-black">
+      <aside className="w-full md:w-80 md:min-w-64 bg-white p-6 flex flex-col border-b md:border-b-0 md:border-r border-gray-200 text-black overflow-y-auto md:h-screen md:sticky md:top-0">
         <h2 className="text-xl font-bold mb-4 flex items-center gap-2">
           <AcademicCapIcon className="w-6 h-6" /> Classroom
         </h2>
@@ -204,7 +204,7 @@ export default function ClassroomPage() {
           </div>
         )}
       </aside>
-      <main className="flex-1 bg-white p-4 md:p-10 flex flex-col text-black">
+      <main className="flex-1 bg-white p-4 md:p-10 flex flex-col text-black overflow-y-auto">
         {selected ? (
           <>
             <h1 className="text-2xl font-bold mb-3">{selected.title}</h1>

--- a/src/app/components/PostCard.tsx
+++ b/src/app/components/PostCard.tsx
@@ -34,12 +34,13 @@ interface Props {
   post: Post;
   user: User;
   onDelete?: (id: string) => void;
+  onShare?: (newPost: Post) => void;
 }
 
 const BASE_URL = "https://www.vone.mn";
 const UPLOADS_URL = `${BASE_URL}/api/uploads`;
 
-export default function PostCard({ post, user, onDelete }: Props) {
+export default function PostCard({ post, user, onDelete, onShare }: Props) {
   const { user: viewer, login } = useAuth();
   const isPro = user.subscriptionExpiresAt
     ? new Date(user.subscriptionExpiresAt) > new Date()
@@ -80,6 +81,9 @@ export default function PostCard({ post, user, onDelete }: Props) {
       );
       setShares(data.shares);
       setShared(true);
+      if (data.newPost) {
+        onShare?.(data.newPost);
+      }
       login({ ...viewer, rating: (viewer.rating || 0) + 1 }, viewer.accessToken);
     } catch (err) {
       console.error("Share error:", err);

--- a/src/app/profile/[id]/page.tsx
+++ b/src/app/profile/[id]/page.tsx
@@ -51,6 +51,10 @@ export default function PublicProfilePage() {
     const BASE_URL = "https://www.vone.mn";
     const UPLOADS_URL = `${BASE_URL}/api/uploads`;
 
+    const handleShareAdd = (newPost: PostData) => {
+        setUserPosts((prev) => [newPost, ...prev]);
+    };
+
     useEffect(() => {
         if (!userId) return;
         setLoading(true);
@@ -156,7 +160,12 @@ export default function PublicProfilePage() {
                 )}
                 <div className="space-y-4">
                     {userPosts.map((post) => (
-                        <PostCard key={post._id} post={post} user={userData} />
+                        <PostCard
+                            key={post._id}
+                            post={post}
+                            user={userData}
+                            onShare={handleShareAdd}
+                        />
                     ))}
                 </div>
             </div>

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -51,6 +51,10 @@ export default function MyOwnProfilePage() {
         }
     };
 
+    const handleShareAdd = (newPost: PostData) => {
+        setUserPosts((prev) => [newPost, ...prev]);
+    };
+
     const BASE_URL = "https://www.vone.mn";
     const UPLOADS_URL = `${BASE_URL}/api/uploads`;
 
@@ -199,6 +203,7 @@ export default function MyOwnProfilePage() {
                                 post={post}
                                 user={userData}
                                 onDelete={handleDelete}
+                                onShare={handleShareAdd}
                             />
                         ))}
                     </div>


### PR DESCRIPTION
## Summary
- show shared posts on profile by hooking PostCard onShare
- update profile pages to handle newly shared posts
- make classroom sidebar sticky and scrollable on mobile

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685498e5d6c48328ab3ea138f953ed1b