### PR TITLE
Add shared Post type

### DIFF
--- a/src/app/components/PostCard.tsx
+++ b/src/app/components/PostCard.tsx
@@ -10,24 +10,13 @@ import {
 import { formatPostDate } from "../lib/formatDate";
 import { useAuth } from "../context/AuthContext";
 import axios from "axios";
+import type { Post } from "@/types/Post";
 
 interface User {
   _id?: string;
   username: string;
   profilePicture?: string;
   subscriptionExpiresAt?: string;
-}
-
-interface Post {
-  _id: string;
-  sharedFrom?: Post;
-  content: string;
-  image?: string;
-  createdAt: string;
-  likes?: string[];
-  comments?: any[];
-  shares?: number;
-  user?: User & { _id: string };
 }
 
 interface Props {

--- a/src/app/profile/[id]/page.tsx
+++ b/src/app/profile/[id]/page.tsx
@@ -4,6 +4,7 @@ import { useRouter, useParams } from "next/navigation";
 import { FaCheckCircle } from "react-icons/fa";
 import PostCard from "../../components/PostCard";
 import axios from "axios";
+import type { Post } from "@/types/Post";
 
 /**
  * Matches your new user schema (no "name" field).
@@ -25,17 +26,6 @@ interface UserData {
  * If your posts actually have "title" + "content", keep them.
  * Otherwise remove "title" references.
  */
-interface PostData {
-    _id: string;
-    title: string;
-    content: string;
-    createdAt: string;
-    sharedFrom?: PostData;
-    image?: string;
-    likes?: string[];
-    comments?: any[];
-    shares?: number;
-}
 
 export default function PublicProfilePage() {
     const router = useRouter();
@@ -43,7 +33,7 @@ export default function PublicProfilePage() {
     const userId = params.id as string;
 
     const [userData, setUserData] = useState<UserData | null>(null);
-    const [userPosts, setUserPosts] = useState<PostData[]>([]);
+    const [userPosts, setUserPosts] = useState<Post[]>([]);
     const [loading, setLoading] = useState(true);
     const [postLoading, setPostLoading] = useState(false);
     const [error, setError] = useState("");
@@ -51,7 +41,7 @@ export default function PublicProfilePage() {
     const BASE_URL = "https://www.vone.mn";
     const UPLOADS_URL = `${BASE_URL}/api/uploads`;
 
-    const handleShareAdd = (newPost: PostData) => {
+    const handleShareAdd = (newPost: Post) => {
         setUserPosts((prev) => [newPost, ...prev]);
     };
 

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -4,6 +4,7 @@ import axios from "axios";
 import { useRouter } from "next/navigation";
 import { FaCheckCircle } from "react-icons/fa";
 import PostCard from "../components/PostCard";
+import type { Post } from "@/types/Post";
 
 /** Match your user schema. No "name" field. */
 interface UserData {
@@ -18,22 +19,11 @@ interface UserData {
     location?: string;
 }
 
-interface PostData {
-    _id: string;
-    title: string;
-    content: string;
-    createdAt: string;
-    sharedFrom?: PostData;
-    image?: string;
-    likes?: string[];
-    comments?: any[];
-    shares?: number;
-}
 
 export default function MyOwnProfilePage() {
     const router = useRouter();
     const [userData, setUserData] = useState<UserData | null>(null);
-    const [userPosts, setUserPosts] = useState<PostData[]>([]);
+    const [userPosts, setUserPosts] = useState<Post[]>([]);
     const [loadingProfile, setLoadingProfile] = useState(true);
     const [loadingPosts, setLoadingPosts] = useState(false);
     const [error, setError] = useState("");
@@ -51,7 +41,7 @@ export default function MyOwnProfilePage() {
         }
     };
 
-    const handleShareAdd = (newPost: PostData) => {
+    const handleShareAdd = (newPost: Post) => {
         setUserPosts((prev) => [newPost, ...prev]);
     };
 

--- a/src/types/Post.ts
+++ b/src/types/Post.ts
@@ -1,0 +1,13 @@
+export interface Post {
+  _id: string;
+  title?: string;
+  content: string;
+  createdAt: string;
+  sharedFrom?: Post;
+  image?: string;
+  images?: string[];
+  likes?: (string | any)[];
+  comments?: any[];
+  shares?: number;
+  user?: any;
+}


### PR DESCRIPTION
## Summary
- create a central `Post` interface under `src/types`
- refactor `PostCard` and both profile pages to use the shared type

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'react' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68549ba801fc8328b391bdff5f2b7bbd