### PR TITLE
Replace img tags with Next.js Image

### DIFF
--- a/src/app/books/page.tsx
+++ b/src/app/books/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import Link from "next/link";
+import Image from "next/image";
 import { useAuth } from "../context/AuthContext";
 import type { Book } from "../lib/books";
 
@@ -45,9 +46,11 @@ export default function BooksPage() {
           >
             <div className="h-48 mb-3 overflow-hidden rounded">
               {book.coverImageUrl ? (
-                <img
+                <Image
                   src={`${BASE_URL}/${book.coverImageUrl}`}
                   alt={book.title}
+                  width={400}
+                  height={192}
                   className="w-full h-full object-cover"
                 />
               ) : (

--- a/src/app/components/Header.tsx
+++ b/src/app/components/Header.tsx
@@ -1,6 +1,7 @@
 "use client";
 import React, { useState } from "react";
 import Link from "next/link";
+import Image from "next/image";
 import { UserCircleIcon } from "@heroicons/react/24/solid";
 import { useAuth } from "../context/AuthContext";
 
@@ -36,9 +37,11 @@ export default function Header() {
                         {loggedIn ? (
                             <Link href="/profile" aria-label="Profile">
                                 {user?.profilePicture ? (
-                                    <img
+                                    <Image
                                         src={`${BASE_URL}${user.profilePicture}`}
                                         alt="Profile"
+                                        width={32}
+                                        height={32}
                                         className="w-8 h-8 rounded-full object-cover"
                                     />
                                 ) : (

--- a/src/app/components/HomeSlider.tsx
+++ b/src/app/components/HomeSlider.tsx
@@ -1,11 +1,14 @@
 "use client";
+import Image from "next/image";
 export default function HomeSlider() {
   return (
     <div className="mb-6">
       <div className="h-60 md:h-72 flex items-center justify-center rounded-lg overflow-hidden bg-gray-900">
-        <img
+        <Image
           src="/vercel.svg"
           alt="Hero"
+          width={500}
+          height={240}
           className="w-full h-full object-contain"
         />
       </div>

--- a/src/app/components/PostCard.tsx
+++ b/src/app/components/PostCard.tsx
@@ -1,6 +1,7 @@
 "use client";
 import React, { useState } from "react";
 import { motion } from "framer-motion";
+import Image from "next/image";
 import { FaCheckCircle } from "react-icons/fa";
 import { BoltIcon, HeartIcon as HeartSolid } from "@heroicons/react/24/solid";
 import {
@@ -113,9 +114,11 @@ export default function PostCard({ post, user, onDelete, onShare }: Props) {
     <div className="bg-white p-6 grid gap-4 border-b border-gray-200">
       <div className="flex gap-3 group">
         {user.profilePicture ? (
-          <img
+          <Image
             src={`${BASE_URL}${user.profilePicture}`}
             alt="avatar"
+            width={40}
+            height={40}
             className="w-10 h-10 rounded-full object-cover"
           />
         ) : (
@@ -180,9 +183,11 @@ export default function PostCard({ post, user, onDelete, onShare }: Props) {
               </p>
             )}
             {displayPost.image && (
-              <img
+              <Image
                 src={`${UPLOADS_URL}/${displayPost.image}`}
                 alt="Post"
+                width={800}
+                height={600}
                 className="w-full rounded-lg mt-2 object-cover"
               />
             )}

--- a/src/app/components/PostInput.tsx
+++ b/src/app/components/PostInput.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useRef, useState } from "react";
+import Image from "next/image";
 import {
   PhotoIcon,
   FaceSmileIcon,
@@ -70,9 +71,11 @@ export default function PostInput({ onPost }: Props) {
   return (
     <div className="flex bg-white rounded-2xl border border-gray-100 shadow-sm p-4 md:p-6 max-w-xl mx-auto">
       {user?.profilePicture ? (
-        <img
+        <Image
           src={`${BASE_URL}${user.profilePicture}`}
           alt="Avatar"
+          width={48}
+          height={48}
           className="w-12 h-12 rounded-full mr-4 object-cover ring-2 ring-brandCyan"
         />
       ) : (

--- a/src/app/components/SubscriptionPage.tsx
+++ b/src/app/components/SubscriptionPage.tsx
@@ -1,6 +1,7 @@
 "use client";
 import React, { useState, useEffect } from "react";
 import axios from "axios";
+import Image from "next/image";
 import { useAuth } from "../context/AuthContext";
 
 interface PaymentOption {
@@ -122,9 +123,11 @@ export default function SubscriptionPage() {
                     {qrUrl && (
                         <div className="text-center">
                             <p className="mb-2 text-gray-400">QR уншуулна уу:</p>
-                            <img
+                            <Image
                                 src={qrUrl}
                                 alt="QPay Subscription"
+                                width={192}
+                                height={192}
                                 className="mx-auto w-48 h-48 border rounded"
                             />
                         </div>
@@ -143,9 +146,11 @@ export default function SubscriptionPage() {
                                             rel="noopener noreferrer"
                                             className="flex flex-col items-center space-y-2"
                                         >
-                                            <img
+                                            <Image
                                                 src={option.logo}
                                                 alt={option.name}
+                                                width={48}
+                                                height={48}
                                                 className="w-12 h-12 object-contain"
                                             />
                                             <span className="text-sm text-blue-400 hover:underline">

--- a/src/app/components/Timeline.tsx
+++ b/src/app/components/Timeline.tsx
@@ -1,6 +1,7 @@
 "use client";
 import React from "react";
 import { motion } from "framer-motion";
+import Image from "next/image";
 
 export interface StoryPost {
     title: string;
@@ -33,9 +34,11 @@ const Timeline: React.FC<TimelineProps> = ({ posts = [] }) => {
                         <div className="flex-shrink-0 relative z-10">
                             <div className="w-12 h-12 flex items-center justify-center bg-[#0055FF] text-white rounded-md shadow-lg">
                                 {post.imageUrl ? (
-                                    <img
+                                    <Image
                                         src={post.imageUrl}
                                         alt={post.title}
+                                        width={48}
+                                        height={48}
                                         className="w-full h-full object-cover rounded-md"
                                     />
                                 ) : (

--- a/src/app/components/TopActiveMembers.tsx
+++ b/src/app/components/TopActiveMembers.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { useEffect, useState } from "react";
 import axios from "axios";
+import Image from "next/image";
 import { UserIcon } from "@heroicons/react/24/solid";
 
 interface Member {
@@ -40,9 +41,11 @@ export default function TopActiveMembers() {
         {members.map((m) => (
           <li key={m._id} className="flex items-center gap-2">
             {m.profilePicture ? (
-              <img
+              <Image
                 src={`${BASE_URL}${m.profilePicture}`}
                 alt={m.username}
+                width={32}
+                height={32}
                 className="w-8 h-8 rounded-full object-cover border border-brandCyan"
               />
             ) : (

--- a/src/app/dashboard/books/page.tsx
+++ b/src/app/dashboard/books/page.tsx
@@ -2,6 +2,7 @@
 
 import React, { useEffect, useState, useRef, FormEvent } from "react";
 import { useRouter } from "next/navigation";
+import Image from "next/image";
 import { useAuth } from "../../context/AuthContext";
 
 interface Book {
@@ -265,9 +266,11 @@ function BookRow({
     <div className="bg-white border border-gray-300 p-4 rounded flex flex-col md:flex-row gap-4 items-start">
       <div className="w-24 h-24 bg-gray-100 flex-shrink-0 overflow-hidden">
         {book.coverImageUrl ? (
-          <img
+          <Image
             src={`https://www.vone.mn/${book.coverImageUrl}`}
             alt={book.title}
+            width={96}
+            height={96}
             className="w-full h-full object-cover"
           />
         ) : (

--- a/src/app/dashboard/products/page.tsx
+++ b/src/app/dashboard/products/page.tsx
@@ -2,6 +2,7 @@
 
 import React, { useEffect, useState, useRef, FormEvent } from "react";
 import { useRouter } from "next/navigation";
+import Image from "next/image";
 import { useAuth } from "../../context/AuthContext";
 
 /* ── types ─────────────────────────────────────────── */
@@ -274,9 +275,11 @@ function ProductRow({
       {/* thumbnail */}
       <div className="w-24 h-24 bg-gray-100 flex-shrink-0 overflow-hidden">
         {product.imageUrl ? (
-          <img
+          <Image
             src={`https://www.vone.mn/${product.imageUrl}`}
             alt={product.name}
+            width={96}
+            height={96}
             className="w-full h-full object-cover"
           />
         ) : (

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,6 +7,7 @@ import React, {
 } from "react";
 import axios from "axios";
 import Link from "next/link";
+import Image from "next/image";
 import { useRouter } from "next/navigation";
 import { useAuth } from "./context/AuthContext";
 import {
@@ -431,9 +432,11 @@ export default function HomePage() {
                       {/* Avatar */}
                       <div className="self-start">
                         {postUser?.profilePicture ? (
-                          <img
+                          <Image
                             src={`${BASE_URL}${postUser.profilePicture}`}
                             alt="Avatar"
+                            width={48}
+                            height={48}
                             className="w-12 h-12 object-cover rounded-md"
                             onError={(e) => (e.currentTarget.style.display = "none")}
                           />
@@ -527,9 +530,11 @@ export default function HomePage() {
                           )}
                           { (post.sharedFrom ? post.sharedFrom.image : post.image) && (
                             <div className="relative w-full overflow-hidden rounded-lg mt-2">
-                              <img
+                              <Image
                                 src={`${UPLOADS_URL}/${post.sharedFrom ? post.sharedFrom.image : post.image}`}
                                 alt="Post"
+                                width={800}
+                                height={600}
                                 className="w-full h-auto object-cover rounded-lg"
                                 onError={(e) => (e.currentTarget.style.display = "none")}
                               />
@@ -592,9 +597,11 @@ export default function HomePage() {
                           <div key={comment._id} className="ml-4">
                             <div className="flex items-start gap-2">
                               {comment.user?.profilePicture && (
-                                <img
+                                <Image
                                   src={`${BASE_URL}${comment.user.profilePicture}`}
                                   alt="avatar"
+                                  width={24}
+                                  height={24}
                                   className="w-6 h-6 rounded-full object-cover"
                                 />
                               )}
@@ -611,9 +618,11 @@ export default function HomePage() {
                                     className="ml-4 mt-2 flex gap-2 items-start"
                                   >
                                     {reply.user?.profilePicture && (
-                                      <img
+                                      <Image
                                         src={`${BASE_URL}${reply.user.profilePicture}`}
                                         alt="avatar"
+                                        width={20}
+                                        height={20}
                                         className="w-5 h-5 rounded-full object-cover"
                                       />
                                     )}

--- a/src/app/profile/[id]/page.tsx
+++ b/src/app/profile/[id]/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 import React, { useEffect, useState } from "react";
 import { useRouter, useParams } from "next/navigation";
+import Image from "next/image";
 import { FaCheckCircle } from "react-icons/fa";
 import PostCard from "../../components/PostCard";
 import axios from "axios";
@@ -116,11 +117,11 @@ export default function PublicProfilePage() {
             {/* Banner */}
             <div className="h-40 bg-[#0d0d0d] relative mt-12">
                 {userData.coverImage && (
-                    <img src={userData.coverImage} alt="Cover" className="absolute inset-0 w-full h-full object-cover" />
+                    <Image src={userData.coverImage} alt="Cover" width={800} height={160} className="absolute inset-0 w-full h-full object-cover" />
                 )}
                 <div className="absolute -bottom-16 left-4 w-32 h-32 rounded-full border-4 border-[#0d0d0d] overflow-hidden bg-gray-800">
                     {userData.profilePicture && (
-                        <img src={userData.profilePicture} alt="Profile" className="w-full h-full object-cover" />
+                        <Image src={userData.profilePicture} alt="Profile" width={128} height={128} className="w-full h-full object-cover" />
                     )}
                 </div>
             </div>

--- a/src/app/profile/edit/page.tsx
+++ b/src/app/profile/edit/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
+import Image from "next/image";
 import { useAuth } from "../../context/AuthContext";
 
 export default function EditProfilePage() {
@@ -54,7 +55,7 @@ export default function EditProfilePage() {
         <div>
           <label className="block mb-1">Profile Picture</label>
           {profilePreview && (
-            <img src={profilePreview} alt="Profile preview" className="w-24 h-24 object-cover rounded-full mb-2" />
+            <Image src={profilePreview} alt="Profile preview" width={96} height={96} className="w-24 h-24 object-cover rounded-full mb-2" />
           )}
           <input
             type="file"
@@ -71,7 +72,7 @@ export default function EditProfilePage() {
         <div>
           <label className="block mb-1">Cover Image</label>
           {coverPreview && (
-            <img src={coverPreview} alt="Cover preview" className="w-full h-40 object-cover rounded mb-2" />
+            <Image src={coverPreview} alt="Cover preview" width={600} height={160} className="w-full h-40 object-cover rounded mb-2" />
           )}
           <input
             type="file"

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -2,6 +2,7 @@
 import React, { useState, useEffect } from "react";
 import axios from "axios";
 import { useRouter } from "next/navigation";
+import Image from "next/image";
 import { FaCheckCircle } from "react-icons/fa";
 import PostCard from "../components/PostCard";
 import type { Post } from "@/types/Post";
@@ -143,11 +144,11 @@ export default function MyOwnProfilePage() {
             {/* Banner */}
             <div className="h-40 bg-[#0d0d0d] relative mt-12">
                 {userData.coverImage && (
-                    <img src={`${BASE_URL}${userData.coverImage}`} alt="Cover" className="absolute inset-0 w-full h-full object-cover" />
+                    <Image src={`${BASE_URL}${userData.coverImage}`} alt="Cover" width={800} height={160} className="absolute inset-0 w-full h-full object-cover" />
                 )}
                 <div className="absolute -bottom-16 left-4 w-32 h-32 rounded-full border-4 border-[#0d0d0d] overflow-hidden bg-gray-200">
                     {userData.profilePicture ? (
-                        <img src={`${BASE_URL}${userData.profilePicture}`} alt="avatar" className="w-full h-full object-cover" />
+                        <Image src={`${BASE_URL}${userData.profilePicture}`} alt="avatar" width={128} height={128} className="w-full h-full object-cover" />
                     ) : null}
                 </div>
             </div>

--- a/src/app/users/page.tsx
+++ b/src/app/users/page.tsx
@@ -2,6 +2,7 @@
 import React, { useEffect, useState } from "react";
 import { motion } from "framer-motion";
 import Link from "next/link";
+import Image from "next/image";
 import axios from "axios";
 
 interface User {
@@ -61,9 +62,11 @@ export default function UsersPage() {
                             transition={{ type: "spring", stiffness: 300 }}
                         >
                         {user.profilePicture ? (
-                            <img
+                            <Image
                                 src={`${BASE_URL}${user.profilePicture}`}
                                 alt={user.username}
+                                width={80}
+                                height={80}
                                 className="w-20 h-20 rounded-full object-cover mb-3"
                             />
                         ) : (


### PR DESCRIPTION
## Summary
- use `next/image` instead of `img` elements across components and pages
- add width and height attributes for each image

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854a6c80a2c8328b284414d3f205e89