### PR TITLE
Fix base URLs for assets

### DIFF
--- a/src/app/books/page.tsx
+++ b/src/app/books/page.tsx
@@ -4,14 +4,13 @@ import { useEffect, useState } from "react";
 import Link from "next/link";
 import { useAuth } from "../context/AuthContext";
 import type { Book } from "../lib/books";
+import { API_URL, BASE_URL } from "../lib/config";
 
 export default function BooksPage() {
   const { user, loggedIn, loading } = useAuth();
   const [books, setBooks] = useState<Book[]>([]);
 
-  const BACKEND_URL =
-    process.env.NEXT_PUBLIC_BACKEND_URL ?? "https://www.vone.mn/api";
-  const BASE_URL = "https://www.vone.mn";
+  const BACKEND_URL = API_URL;
 
   const isPro =
     user?.subscriptionExpiresAt &&

--- a/src/app/classroom/page.tsx
+++ b/src/app/classroom/page.tsx
@@ -109,7 +109,7 @@ export default function ClassroomPage() {
 
   return (
     <div className="flex flex-col md:flex-row h-full w-full min-h-screen">
-      <aside className="w-full md:w-80 md:min-w-64 bg-white p-6 flex flex-col border-b md:border-b-0 md:border-r border-gray-200 text-black">
+      <aside className="w-full md:w-80 md:min-w-64 bg-white p-6 flex flex-col border-b md:border-b-0 md:border-r border-gray-200 text-black overflow-y-auto md:h-screen md:sticky md:top-0">
         <h2 className="text-xl font-bold mb-4 flex items-center gap-2">
           <AcademicCapIcon className="w-6 h-6" /> Classroom
         </h2>
@@ -204,7 +204,7 @@ export default function ClassroomPage() {
           </div>
         )}
       </aside>
-      <main className="flex-1 bg-white p-4 md:p-10 flex flex-col text-black">
+      <main className="flex-1 bg-white p-4 md:p-10 flex flex-col text-black overflow-y-auto">
         {selected ? (
           <>
             <h1 className="text-2xl font-bold mb-3">{selected.title}</h1>

--- a/src/app/components/Header.tsx
+++ b/src/app/components/Header.tsx
@@ -3,11 +3,11 @@ import React, { useState } from "react";
 import Link from "next/link";
 import { UserCircleIcon } from "@heroicons/react/24/solid";
 import { useAuth } from "../context/AuthContext";
+import { BASE_URL } from "../lib/config";
 
 export default function Header() {
     const [isMenuOpen, setIsMenuOpen] = useState(false);
     const { loggedIn, logout, user } = useAuth();
-    const BASE_URL = "https://www.vone.mn";
     const isPro =
         user?.subscriptionExpiresAt &&
         new Date(user.subscriptionExpiresAt) > new Date();

--- a/src/app/components/PostCard.tsx
+++ b/src/app/components/PostCard.tsx
@@ -10,6 +10,7 @@ import {
 import { formatPostDate } from "../lib/formatDate";
 import { useAuth } from "../context/AuthContext";
 import axios from "axios";
+import { BASE_URL, UPLOADS_URL } from "../lib/config";
 
 interface User {
   _id?: string;
@@ -34,12 +35,11 @@ interface Props {
   post: Post;
   user: User;
   onDelete?: (id: string) => void;
+  onShare?: (newPost: Post) => void;
 }
 
-const BASE_URL = "https://www.vone.mn";
-const UPLOADS_URL = `${BASE_URL}/api/uploads`;
 
-export default function PostCard({ post, user, onDelete }: Props) {
+export default function PostCard({ post, user, onDelete, onShare }: Props) {
   const { user: viewer, login } = useAuth();
   const isPro = user.subscriptionExpiresAt
     ? new Date(user.subscriptionExpiresAt) > new Date()
@@ -80,6 +80,9 @@ export default function PostCard({ post, user, onDelete }: Props) {
       );
       setShares(data.shares);
       setShared(true);
+      if (data.newPost) {
+        onShare?.(data.newPost);
+      }
       login({ ...viewer, rating: (viewer.rating || 0) + 1 }, viewer.accessToken);
     } catch (err) {
       console.error("Share error:", err);

--- a/src/app/components/PostInput.tsx
+++ b/src/app/components/PostInput.tsx
@@ -10,8 +10,7 @@ import {
 } from "@heroicons/react/24/outline";
 import { useAuth } from "../context/AuthContext";
 import axios from "axios";
-
-const BASE_URL = "https://www.vone.mn";
+import { BASE_URL } from "../lib/config";
 
 interface Props {
   onPost?: (post?: any) => void;

--- a/src/app/components/SubscriptionPage.tsx
+++ b/src/app/components/SubscriptionPage.tsx
@@ -2,6 +2,7 @@
 import React, { useState, useEffect } from "react";
 import axios from "axios";
 import { useAuth } from "../context/AuthContext";
+import { BASE_URL } from "../lib/config";
 
 interface PaymentOption {
     link: string;
@@ -18,7 +19,6 @@ export default function SubscriptionPage() {
     const [message, setMessage] = useState("");
     const [paid, setPaid] = useState(false);
     const [isMobile, setIsMobile] = useState(false);
-    const BASE_URL = "https://www.vone.mn";
 
     useEffect(() => {
         const userAgent = navigator.userAgent || navigator.vendor;

--- a/src/app/components/TopActiveMembers.tsx
+++ b/src/app/components/TopActiveMembers.tsx
@@ -2,6 +2,7 @@
 import { useEffect, useState } from "react";
 import axios from "axios";
 import { UserIcon } from "@heroicons/react/24/solid";
+import { BASE_URL } from "../lib/config";
 
 interface Member {
   _id: string;
@@ -10,7 +11,6 @@ interface Member {
   rating?: number;
 }
 
-const BASE_URL = "https://www.vone.mn";
 
 export default function TopActiveMembers() {
   const [members, setMembers] = useState<Member[]>([]);

--- a/src/app/components/TrendingTopics.tsx
+++ b/src/app/components/TrendingTopics.tsx
@@ -2,6 +2,7 @@
 import React, { useEffect, useState } from "react";
 import axios from "axios";
 import { FiTrendingUp } from "react-icons/fi";
+import { BASE_URL } from "../lib/config";
 
 interface Post {
   _id: string;
@@ -17,7 +18,6 @@ interface TrendingItem {
   score: number;
 }
 
-const BASE_URL = "https://www.vone.mn";
 
 const TrendingTopics: React.FC = () => {
   const [topics, setTopics] = useState<TrendingItem[]>([]);

--- a/src/app/lib/config.ts
+++ b/src/app/lib/config.ts
@@ -1,0 +1,3 @@
+export const API_URL = process.env.NEXT_PUBLIC_BACKEND_URL ?? 'https://www.vone.mn/api';
+export const BASE_URL = API_URL.replace(/\/api$/, '');
+export const UPLOADS_URL = `${BASE_URL}/api/uploads`;

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -3,6 +3,7 @@ import React, { useState, useEffect } from "react";
 import axios from "axios";
 import { useRouter } from "next/navigation";
 import { useAuth } from "@/app/context/AuthContext";
+import { BASE_URL } from "../lib/config";
 
 export default function LoginPage() {
     const router = useRouter();
@@ -12,7 +13,6 @@ export default function LoginPage() {
     const [remember, setRemember] = useState(false);
     const [error, setError] = useState("");
 
-    const BASE_URL = "https://www.vone.mn";
 
     useEffect(() => {
         const savedUser = localStorage.getItem("rememberUsername");

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,6 +6,7 @@ import React, {
   useRef,
 } from "react";
 import axios from "axios";
+import { BASE_URL, UPLOADS_URL } from "./lib/config";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useAuth } from "./context/AuthContext";
@@ -92,8 +93,6 @@ export default function HomePage() {
     user?.subscriptionExpiresAt &&
     new Date(user.subscriptionExpiresAt) > new Date();
 
-  const BASE_URL = "https://www.vone.mn";
-  const UPLOADS_URL = `${BASE_URL}/api/uploads`;
 
   // redirect guest
   useEffect(() => {

--- a/src/app/profile/[id]/page.tsx
+++ b/src/app/profile/[id]/page.tsx
@@ -4,6 +4,7 @@ import { useRouter, useParams } from "next/navigation";
 import { FaCheckCircle } from "react-icons/fa";
 import PostCard from "../../components/PostCard";
 import axios from "axios";
+import { BASE_URL, UPLOADS_URL } from "../../lib/config";
 
 /**
  * Matches your new user schema (no "name" field).
@@ -48,8 +49,10 @@ export default function PublicProfilePage() {
     const [postLoading, setPostLoading] = useState(false);
     const [error, setError] = useState("");
 
-    const BASE_URL = "https://www.vone.mn";
-    const UPLOADS_URL = `${BASE_URL}/api/uploads`;
+
+    const handleShareAdd = (newPost: PostData) => {
+        setUserPosts((prev) => [newPost, ...prev]);
+    };
 
     useEffect(() => {
         if (!userId) return;
@@ -156,7 +159,12 @@ export default function PublicProfilePage() {
                 )}
                 <div className="space-y-4">
                     {userPosts.map((post) => (
-                        <PostCard key={post._id} post={post} user={userData} />
+                        <PostCard
+                            key={post._id}
+                            post={post}
+                            user={userData}
+                            onShare={handleShareAdd}
+                        />
                     ))}
                 </div>
             </div>

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -4,6 +4,7 @@ import axios from "axios";
 import { useRouter } from "next/navigation";
 import { FaCheckCircle } from "react-icons/fa";
 import PostCard from "../components/PostCard";
+import { BASE_URL, UPLOADS_URL } from "../lib/config";
 
 /** Match your user schema. No "name" field. */
 interface UserData {
@@ -51,8 +52,10 @@ export default function MyOwnProfilePage() {
         }
     };
 
-    const BASE_URL = "https://www.vone.mn";
-    const UPLOADS_URL = `${BASE_URL}/api/uploads`;
+    const handleShareAdd = (newPost: PostData) => {
+        setUserPosts((prev) => [newPost, ...prev]);
+    };
+
 
     // Grab token from localStorage or redirect if missing
     function getToken() {
@@ -199,6 +202,7 @@ export default function MyOwnProfilePage() {
                                 post={post}
                                 user={userData}
                                 onDelete={handleDelete}
+                                onShare={handleShareAdd}
                             />
                         ))}
                     </div>

--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -2,6 +2,7 @@
 import React, { useState } from "react";
 import axios from "axios";
 import { useRouter } from "next/navigation";
+import { BASE_URL } from "../lib/config";
 
 /** Helper validations **/
 const isValidPhoneNumber = (phone: string) => {
@@ -56,7 +57,6 @@ export default function RegisterMultiStepPage() {
     });
 
     // Replace with your actual server endpoint
-    const BASE_URL = "https://www.vone.mn";
 
     // ------------------------------------------------------------------
     // STEP 1: Validate Basic Fields and proceed to next step

--- a/src/app/subscription/page.tsx
+++ b/src/app/subscription/page.tsx
@@ -3,6 +3,7 @@ import React, { useState, useEffect } from "react";
 import axios from "axios";
 import Link from "next/link";
 import { useAuth } from "../context/AuthContext";
+import { BASE_URL } from "../lib/config";
 
 // ── Types ───────────────────────────────────────────────
 // No QPay integration. Payment is handled manually via bank transfer.
@@ -21,7 +22,6 @@ export default function SubscriptionPage() {
     user?.subscriptionExpiresAt &&
     new Date(user.subscriptionExpiresAt) > new Date();
 
-  const BASE_URL = "https://www.vone.mn";
   const price =
     memberCount < 10 ? 10000 : memberCount < 30 ? 20000 : 20000; // 0-9 → 10 k, 10-29 → 20 k, 30+ → 20 k
 

--- a/src/app/users/page.tsx
+++ b/src/app/users/page.tsx
@@ -3,6 +3,7 @@ import React, { useEffect, useState } from "react";
 import { motion } from "framer-motion";
 import Link from "next/link";
 import axios from "axios";
+import { BASE_URL } from "../lib/config";
 
 interface User {
     _id: string;
@@ -16,7 +17,6 @@ export default function UsersPage() {
     const [users, setUsers] = useState<User[]>([]);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState("");
-    const BASE_URL = "https://www.vone.mn";
 
     useEffect(() => {
         const fetchUsers = async () => {


### PR DESCRIPTION
## Summary
- centralize API/asset URLs in `lib/config`
- use shared BASE_URL and UPLOADS_URL across pages and components
- keep newly shared posts visible and maintain edit/delete menu

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685498e5d6c48328ab3ea138f953ed1b