### PR TITLE
Add Web Push hook with tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,4 @@
+const nextJest = require('next/jest');
+const createJestConfig = nextJest({ dir: './' });
+const customJestConfig = { testEnvironment: 'jsdom' };
+module.exports = createJestConfig(customJestConfig);

--- a/package.json
+++ b/package.json
@@ -65,7 +65,8 @@
     "nodemon": "^2.0.22",
     "postcss": "^8",
     "tailwindcss": "^3.4.1",
-    "typescript": "^5"
+    "typescript": "^5",
+    "@testing-library/react": "^14.1.0"
   },
   "description": "This project is a Next.js application, bootstrapped with create-next-app. It also includes a Node.js backend server for handling API requests and managing user authentication.",
   "main": "server/index.js",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,9 @@
+self.addEventListener('push', event => {
+  const data = event.data ? event.data.json() : {};
+  const title = data.title || 'Notification';
+  const options = {
+    body: data.body,
+    icon: data.icon || '/android-chrome-192x192.png'
+  };
+  event.waitUntil(self.registration.showNotification(title, options));
+});

--- a/src/app/hooks/useWebPush.test.tsx
+++ b/src/app/hooks/useWebPush.test.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { render, act } from '@testing-library/react';
+import useWebPush from './useWebPush';
+
+test('subscribe requests permission', async () => {
+  const requestPermission = jest.fn().mockResolvedValue('granted');
+  (global as any).Notification = { permission: 'default', requestPermission };
+  (navigator as any).serviceWorker = { register: jest.fn().mockResolvedValue({}) };
+
+  let hook: any;
+  function Wrapper() {
+    hook = useWebPush();
+    return null;
+  }
+
+  render(<Wrapper />);
+  await act(async () => {
+    await hook.subscribe();
+  });
+
+  expect(requestPermission).toHaveBeenCalled();
+});

--- a/src/app/hooks/useWebPush.ts
+++ b/src/app/hooks/useWebPush.ts
@@ -1,0 +1,40 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+
+const FLAG = 'webpush_permission_requested';
+
+async function askPermission(): Promise<boolean> {
+  if (typeof window === 'undefined' || !('Notification' in window)) return false;
+  if (Notification.permission === 'granted') return true;
+  if (sessionStorage.getItem(FLAG)) return Notification.permission === 'granted';
+  sessionStorage.setItem(FLAG, '1');
+  const res = await Notification.requestPermission();
+  return res === 'granted';
+}
+
+export default function useWebPush() {
+  const [subscribed, setSubscribed] = useState(false);
+
+  const subscribe = async () => {
+    if (!('serviceWorker' in navigator)) return;
+    const granted = await askPermission();
+    if (!granted) return;
+    try {
+      await navigator.serviceWorker.register('/sw.js');
+      setSubscribed(true);
+    } catch (e) {
+      console.error('Service worker registration failed', e);
+    }
+  };
+
+  useEffect(() => {
+    if (Notification.permission === 'granted') {
+      navigator.serviceWorker.getRegistration('/sw.js').then((reg) => {
+        if (reg) setSubscribed(true);
+      });
+    }
+  }, []);
+
+  return { subscribed, subscribe };
+}


### PR DESCRIPTION
## Summary
- implement `useWebPush` React hook
- add service worker at `/sw.js`
- configure Jest and add test for the hook
- include testing-library for test utilities

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685530202e68832886b85bab8de47b7b