### PR TITLE
Enable dark mode styling

### DIFF
--- a/src/app/context/ThemeContext.tsx
+++ b/src/app/context/ThemeContext.tsx
@@ -9,19 +9,18 @@ interface ThemeState {
 }
 
 const ThemeContext = createContext<ThemeState>({
-    theme: "light",
+    theme: "dark",
     toggleTheme: () => {},
 });
 
 export function ThemeProvider({ children }: { children: React.ReactNode }) {
-    const [theme, setTheme] = useState<Theme>("light");
+    const [theme, setTheme] = useState<Theme>("dark");
 
     useEffect(() => {
         const stored = localStorage.getItem("theme");
-        if (stored === "dark" || stored === "light") {
-            setTheme(stored);
-            document.documentElement.classList.toggle("dark", stored === "dark");
-        }
+        const initial = stored === "dark" || stored === "light" ? stored : "dark";
+        setTheme(initial);
+        document.documentElement.classList.toggle("dark", initial === "dark");
     }, []);
 
     const toggleTheme = () => {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -24,8 +24,35 @@ html {
 }
 
 html.dark {
-    background-color: #080808;
+    background-color: #181818;
     color-scheme: dark;
+    color: #ffffff;
+}
+
+html.dark body {
+    background-color: #181818;
+    color: #ffffff;
+}
+
+html.dark input,
+html.dark textarea,
+html.dark select {
+    background-color: #1E1E1E;
+    color: #AFAFAF;
+}
+
+html.dark .bg-white {
+    background-color: #212121 !important;
+}
+
+html.dark .text-black {
+    color: #ffffff !important;
+}
+
+html.dark .text-gray-700,
+html.dark .text-gray-800,
+html.dark .text-gray-900 {
+    color: #ffffff !important;
 }
 
 /* Minimal fade-in-up animation for sidebars */

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -63,8 +63,8 @@ export const metadata: Metadata = {
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
     return (
-        <html lang="mn">
-            <body className={`${inter.className} flex flex-col min-h-screen bg-white text-gray-900`}>
+        <html lang="mn" className="dark">
+            <body className={`${inter.className} flex flex-col min-h-screen bg-secondary text-white`}>
                 <LayoutClient>{children}</LayoutClient>
             </body>
         </html>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -10,6 +10,10 @@ module.exports = {
       colors: {
         brandCyan: '#00FFFC',
         supportBorder: '#F6F3E1',
+        primary: '#212121',
+        secondary: '#181818',
+        inputBg: '#1E1E1E',
+        inputText: '#AFAFAF',
       },
       fontFamily: {
         sans: ['Inter', 'Helvetica', 'Arial', 'sans-serif'], // Minimalistic and clean font stack


### PR DESCRIPTION
## Summary
- add dark theme palette in Tailwind
- default to dark mode and read previous choice
- update global styles for dark colors
- make root layout render with dark background

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685677f08eb08328b9ed35aa7ca32d07