### PR TITLE
Improve dark mode header styling

### DIFF
--- a/src/app/components/Header.tsx
+++ b/src/app/components/Header.tsx
@@ -26,7 +26,7 @@ export default function Header() {
             )}
 
             <div
-                className="fixed top-0 left-0 w-full z-[999] bg-gradient-to-b from-white/40 via-white/20 to-transparent backdrop-blur-xl shadow-md"
+                className="fixed top-0 left-0 w-full z-[999] bg-primary text-white border-b border-supportBorder shadow-md"
             >
                 {/* NAV BAR */}
                 <nav className="max-w-7xl mx-auto px-6 py-4 flex items-center">
@@ -110,7 +110,7 @@ export default function Header() {
                 <div
                     className={`
             fixed inset-0
-            bg-white
+            bg-secondary text-white
             transition-transform duration-300
             z-[9999]
             overflow-y-auto

--- a/src/app/context/ThemeContext.tsx
+++ b/src/app/context/ThemeContext.tsx
@@ -9,19 +9,18 @@ interface ThemeState {
 }
 
 const ThemeContext = createContext<ThemeState>({
-    theme: "light",
+    theme: "dark",
     toggleTheme: () => {},
 });
 
 export function ThemeProvider({ children }: { children: React.ReactNode }) {
-    const [theme, setTheme] = useState<Theme>("light");
+    const [theme, setTheme] = useState<Theme>("dark");
 
     useEffect(() => {
         const stored = localStorage.getItem("theme");
-        if (stored === "dark" || stored === "light") {
-            setTheme(stored);
-            document.documentElement.classList.toggle("dark", stored === "dark");
-        }
+        const initial = stored === "dark" || stored === "light" ? stored : "dark";
+        setTheme(initial);
+        document.documentElement.classList.toggle("dark", initial === "dark");
     }, []);
 
     const toggleTheme = () => {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -20,12 +20,40 @@ html {
     background-color: #ffffff;
     color-scheme: light;
     --brand-color: #00FFFC;
-    --support-border: #F6F3E1;
+    --support-border: #2D2D2D;
 }
 
 html.dark {
-    background-color: #080808;
+    background-color: #181818;
     color-scheme: dark;
+    color: #ffffff;
+    --support-border: #2D2D2D;
+}
+
+html.dark body {
+    background-color: #181818;
+    color: #ffffff;
+}
+
+html.dark input,
+html.dark textarea,
+html.dark select {
+    background-color: #1E1E1E;
+    color: #AFAFAF;
+}
+
+html.dark .bg-white {
+    background-color: #212121 !important;
+}
+
+html.dark .text-black {
+    color: #ffffff !important;
+}
+
+html.dark .text-gray-700,
+html.dark .text-gray-800,
+html.dark .text-gray-900 {
+    color: #ffffff !important;
 }
 
 /* Minimal fade-in-up animation for sidebars */

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -63,8 +63,8 @@ export const metadata: Metadata = {
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
     return (
-        <html lang="mn">
-            <body className={`${inter.className} flex flex-col min-h-screen bg-white text-gray-900`}>
+        <html lang="mn" className="dark">
+            <body className={`${inter.className} flex flex-col min-h-screen bg-secondary text-white`}>
                 <LayoutClient>{children}</LayoutClient>
             </body>
         </html>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -9,7 +9,11 @@ module.exports = {
     extend: {
       colors: {
         brandCyan: '#00FFFC',
-        supportBorder: '#F6F3E1',
+        supportBorder: '#2D2D2D',
+        primary: '#212121',
+        secondary: '#181818',
+        inputBg: '#1E1E1E',
+        inputText: '#AFAFAF',
       },
       fontFamily: {
         sans: ['Inter', 'Helvetica', 'Arial', 'sans-serif'], // Minimalistic and clean font stack


### PR DESCRIPTION
## Summary
- tweak support border color for dark theme
- update global CSS variables
- give header a solid dark background and classic styling

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685677f08eb08328b9ed35aa7ca32d07