### PR TITLE
Add YouTube transcription

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "react-loading-skeleton": "^3.5.0",
     "react-slick": "^0.30.3",
     "react-time-picker": "^7.0.0",
+    "ytdl-core": "^4.11.1",
     "slick-carousel": "^1.8.1",
     "stripe": "^17.5.0",
     "swiper": "^11.1.15",

--- a/server/index.js
+++ b/server/index.js
@@ -17,6 +17,7 @@ const productRoutes = require("./routes/productRoutes");
 const cartRoutes    = require("./routes/cartRoutes"); // ← feature branch win
 const notificationRoutes = require("./routes/notification");
 const pushRoutes    = require("./routes/push");
+const youtubeRoutes = require("./routes/youtube");
 const webpush       = require("web-push");
 
 const app  = express();
@@ -72,6 +73,7 @@ app.use("/api/products", productRoutes);
 app.use("/api/cart",     cartRoutes); // ← now live
 app.use("/api/notifications", notificationRoutes);
 app.use("/api/push",     pushRoutes);
+app.use("/api/youtube",  youtubeRoutes);
 
 // ── heartbeat ─────────────────────────────────────────
 app.get("/", (_, res) => res.send("Server is working!"));

--- a/server/routes/youtube.js
+++ b/server/routes/youtube.js
@@ -1,0 +1,39 @@
+const express = require('express');
+const router = express.Router();
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const ytdl = require('ytdl-core');
+const OpenAI = require('openai');
+
+const openai = new OpenAI();
+
+router.post('/transcribe', async (req, res) => {
+  try {
+    const { url } = req.body;
+    if (!url) return res.status(400).json({ error: 'url is required' });
+
+    const tmpFile = path.join(os.tmpdir(), `yt-${Date.now()}.mp3`);
+    await new Promise((resolve, reject) => {
+      const stream = ytdl(url, { filter: 'audioonly', quality: 'highestaudio' });
+      const writeStream = fs.createWriteStream(tmpFile);
+      stream.pipe(writeStream);
+      stream.on('end', resolve);
+      stream.on('error', reject);
+      writeStream.on('error', reject);
+    });
+
+    const transcription = await openai.audio.transcriptions.create({
+      file: fs.createReadStream(tmpFile),
+      model: 'whisper-1',
+    });
+
+    fs.unlink(tmpFile, () => {});
+    res.json({ text: transcription.text });
+  } catch (err) {
+    console.error('Transcription error:', err);
+    res.status(500).json({ error: 'Failed to transcribe' });
+  }
+});
+
+module.exports = router;

--- a/src/app/youtube/page.tsx
+++ b/src/app/youtube/page.tsx
@@ -1,0 +1,45 @@
+"use client";
+import { useState } from "react";
+import axios from "axios";
+import { BASE_URL } from "../lib/config";
+
+export default function YoutubePage() {
+  const [url, setUrl] = useState("");
+  const [text, setText] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  const transcribe = async () => {
+    if (!url.trim()) return;
+    setLoading(true);
+    try {
+      const { data } = await axios.post(`${BASE_URL}/api/youtube/transcribe`, { url });
+      setText(data.text);
+    } catch (err) {
+      console.error("Transcription error", err);
+      setText("Error transcribing video.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen p-4 max-w-2xl mx-auto">
+      <h1 className="text-2xl font-bold mb-4">YouTube Transcriber</h1>
+      <input
+        type="text"
+        placeholder="YouTube URL"
+        className="w-full p-2 border border-gray-300 rounded mb-4 text-black"
+        value={url}
+        onChange={(e) => setUrl(e.target.value)}
+      />
+      <button
+        onClick={transcribe}
+        disabled={loading}
+        className="bg-brandCyan text-black px-4 py-2 rounded"
+      >
+        {loading ? "Transcribing..." : "Transcribe"}
+      </button>
+      {text && <pre className="whitespace-pre-wrap mt-4 text-black">{text}</pre>}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add `/api/youtube` server route to transcribe videos
- wire the route in `server/index.js`
- create a basic frontend page at `/youtube`
- declare `ytdl-core` dependency for downloading audio

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68598705d1f08328b3d46fc86aa108ae