### PR TITLE
Add OpenAI API key test script

### DIFF
--- a/openai-key-test.mjs
+++ b/openai-key-test.mjs
@@ -1,0 +1,23 @@
+import OpenAI from 'openai';
+
+const apiKey = process.env.OPENAI_API_KEY;
+if (!apiKey) {
+  console.error('OPENAI_API_KEY environment variable is not set.');
+  process.exit(1);
+}
+
+const openai = new OpenAI({ apiKey });
+
+async function main() {
+  try {
+    const response = await openai.chat.completions.create({
+      model: 'gpt-3.5-turbo',
+      messages: [{ role: 'user', content: 'Hello!' }]
+    });
+    console.log('API response:', response.choices[0].message.content);
+  } catch (err) {
+    console.error('Failed to call OpenAI API:', err.message);
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary
- create a small utility `openai-key-test.mjs` to check if the `OPENAI_API_KEY` works

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859ac9dff388328a87c89f951ce766d