### PR TITLE
Improve feed design and realtime fallback

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -28,14 +28,14 @@ html {
 }
 
 html.dark {
-    background-color: #0F181E;
+    background-color: #212121;
     color-scheme: dark;
     color: #F5F6F8;
     --support-border: #272F36;
 }
 
 html.dark body {
-    background-color: #0F181E;
+    background-color: #212121;
     color: #F5F6F8;
 }
 

--- a/src/app/hooks/useLiveFeed.ts
+++ b/src/app/hooks/useLiveFeed.ts
@@ -1,7 +1,14 @@
 "use client";
 import { useEffect } from "react";
 import { io, Socket } from "socket.io-client";
-import { LIVE_URL } from "../lib/config";
+
+// Determine the Socket.IO server URL.
+// Fallback to localhost in development if no env variable is provided.
+const LIVE_URL =
+  process.env.NEXT_PUBLIC_LIVE_URL ||
+  (typeof window !== "undefined"
+    ? window.location.origin.replace(/3000$/, "5002")
+    : "http://localhost:5002");
 
 let socket: Socket | null = null;
 

--- a/src/app/lib/config.ts
+++ b/src/app/lib/config.ts
@@ -1,4 +1,5 @@
 export const API_URL = process.env.NEXT_PUBLIC_BACKEND_URL ?? 'https://www.vone.mn/api';
 export const BASE_URL = API_URL.replace(/\/api$/, '');
 export const UPLOADS_URL = `${BASE_URL}/api/uploads`;
-export const LIVE_URL = process.env.NEXT_PUBLIC_LIVE_URL ?? 'https://vone.mn:5002';
+// Default to localhost Socket.IO server when developing.
+export const LIVE_URL = process.env.NEXT_PUBLIC_LIVE_URL ?? 'http://localhost:5002';

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -354,7 +354,7 @@ export default function HomePage() {
   // UI
   // ────────────────────────────────────────────────────────────
   return (
-    <div className="min-h-screen bg-white text-gray-900">
+    <div className="min-h-screen bg-secondary text-white">
       {/* Membership banner */}
       {loggedIn && !isPro && (
         <div className="bg-yellow-500 text-white text-center py-2 px-4">
@@ -379,7 +379,7 @@ export default function HomePage() {
         <main>
           {/* Prompt login */}
           {!loggedIn && (
-            <div className="bg-white p-6 text-center space-y-3">
+            <div className="bg-secondary p-6 text-center space-y-3">
               <p>Feed үзэхийн тулд нэвтрэх эсвэл бүртгүүлэх шаардлагатай.</p>
               <Link href="/login" className="text-blue-600 underline">
                 Нэвтрэх
@@ -395,7 +395,7 @@ export default function HomePage() {
 
           {/* Subscription gate */}
           {loggedIn && !isPro ? (
-            <div className="bg-white p-6 text-center space-y-3">
+            <div className="bg-secondary p-6 text-center space-y-3">
               <p>Feed үзэхийн тулд гишүүнчлэл идэвхжүүлнэ үү.</p>
               <Link href="/subscription" className="text-blue-600 underline">
                 Subscribe
@@ -430,7 +430,7 @@ export default function HomePage() {
                     initial={{ opacity: 0, y: 20 }}
                     animate={{ opacity: 1, y: 0 }}
                     transition={{ delay: idx * 0.02 }}
-                    className="bg-white p-6 grid gap-4 border-b border-gray-200"
+                    className="bg-[#2a2a2a] text-white p-6 grid gap-4 border-b border-gray-700"
                   >
                     {/* Header */}
                     <div className="grid grid-cols-[auto,1fr] gap-5 group">
@@ -501,16 +501,16 @@ export default function HomePage() {
                                 </svg>
                               </button>
                               {openMenus[post._id] && (
-                                <div className="absolute right-0 mt-1 bg-white border rounded shadow">
+                                <div className="absolute right-0 mt-1 bg-[#333] text-white border border-gray-700 rounded shadow">
                                   <button
                                     onClick={() => handleEdit(post)}
-                                    className="block px-3 py-1 text-sm hover:bg-gray-100 w-full text-left"
+                                    className="block px-3 py-1 text-sm hover:bg-gray-600 w-full text-left"
                                   >
                                     Edit
                                   </button>
                                   <button
                                     onClick={() => handleDelete(post._id)}
-                                    className="block px-3 py-1 text-sm hover:bg-gray-100 w-full text-left text-red-500"
+                                    className="block px-3 py-1 text-sm hover:bg-gray-600 w-full text-left text-red-400"
                                   >
                                     Delete
                                   </button>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -9,15 +9,15 @@ module.exports = {
     extend: {
       colors: {
         brand: '#119C99',
-        backgroundDark: '#0F181E',
+        backgroundDark: '#212121',
         surface: '#F5F6F8',
         textPrimary: '#272F36',
         accent: '#FF2C55',
         premium: '#F7B84B',
         link: '#44B2DF',
         supportBorder: '#272F36',
-        primary: '#0F181E',
-        secondary: '#0F181E',
+        primary: '#212121',
+        secondary: '#212121',
         inputBg: '#1E1E1E',
         inputText: '#AFAFAF',
       },


### PR DESCRIPTION
## Summary
- adjust tailwind and globals for darker background
- update newsfeed styles for a minimal dark theme
- add robust LIVE_URL fallback for Socket.IO

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c40bd428883288abd0985b5e3c828