### PR TITLE
Update UI with brand color and profile photo upload

### DIFF
--- a/src/app/components/BottomNav.tsx
+++ b/src/app/components/BottomNav.tsx
@@ -47,27 +47,27 @@ const BottomNav: React.FC = () => {
                 <button
                     onClick={() => router.push("/")}
                     aria-label="Home"
-                    className="p-1 text-black"
+                    className="p-1 text-black hover:text-brand"
                 >
-                    <HomeIcon className="h-7 w-7" />
+                    <HomeIcon className="h-7 w-7 icon-hover-brand" />
                 </button>
 
                 {/* NEW POST */}
                 <button
                     onClick={() => setShowModal(true)}
                     aria-label="New Post"
-                    className="p-1 text-black"
+                    className="p-1 text-black hover:text-brand"
                 >
-                    <PlusCircleIcon className="h-8 w-8" />
+                    <PlusCircleIcon className="h-8 w-8 icon-hover-brand" />
                 </button>
 
                 {/* NOTIFICATIONS */}
                 <button
                     onClick={() => router.push("/notifications")}
                     aria-label="Notifications"
-                    className="relative p-1 text-black"
+                    className="relative p-1 text-black hover:text-brand"
                 >
-                    <BellIcon className="h-7 w-7" />
+                    <BellIcon className="h-7 w-7 icon-hover-brand" />
                     {unreadCount > 0 && (
                         <span className="absolute -top-1 -right-1 bg-red-500 text-white rounded-full text-xs w-5 h-5 flex items-center justify-center">
                             {unreadCount}
@@ -79,9 +79,9 @@ const BottomNav: React.FC = () => {
                 <button
                     onClick={() => router.push("/classroom")}
                     aria-label="Classroom"
-                    className="p-1 text-black"
+                    className="p-1 text-black hover:text-brand"
                 >
-                    <AcademicCapIcon className="h-7 w-7" />
+                    <AcademicCapIcon className="h-7 w-7 icon-hover-brand" />
                 </button>
 
             </div>

--- a/src/app/components/PostCard.tsx
+++ b/src/app/components/PostCard.tsx
@@ -197,13 +197,13 @@ export default function PostCard({ post, user, onDelete, onShare }: Props) {
             <motion.button
               whileTap={{ scale: 0.8 }}
               onClick={handleLike}
-              className="flex items-center justify-center gap-1 hover:text-gray-700"
+              className="flex items-center justify-center gap-1 hover:text-brand"
               aria-label="Like"
             >
               {liked ? (
-                <HeartSolid className="w-4 h-4 text-red-500" />
+                <HeartSolid className="w-4 h-4 text-brand icon-hover-brand" />
               ) : (
-                <HeartOutline className="w-4 h-4" />
+                <HeartOutline className="w-4 h-4 icon-hover-brand" />
               )}
               <span>{likes}</span>
             </motion.button>
@@ -213,11 +213,11 @@ export default function PostCard({ post, user, onDelete, onShare }: Props) {
             <motion.button
               whileTap={{ scale: 0.8 }}
               onClick={handleShare}
-              className="flex items-center justify-center gap-1 hover:text-gray-700"
+              className="flex items-center justify-center gap-1 hover:text-brand"
               aria-label="Share"
             >
               <ArrowUpTrayIcon
-                className={shared ? "w-4 h-4 text-green-500" : "w-4 h-4"}
+                className={shared ? "w-4 h-4 text-brand icon-hover-brand" : "w-4 h-4 icon-hover-brand"}
               />
               <span>{shares}</span>
             </motion.button>

--- a/src/app/components/PostInput.tsx
+++ b/src/app/components/PostInput.tsx
@@ -2,13 +2,7 @@
 
 import React, { useRef, useState } from "react";
 import Image from "next/image";
-import {
-  PhotoIcon,
-  FaceSmileIcon,
-  ChartBarIcon,
-  CalendarIcon,
-  MapPinIcon,
-} from "@heroicons/react/24/outline";
+import { PhotoIcon } from "@heroicons/react/24/outline";
 import { useAuth } from "../context/AuthContext";
 import axios from "axios";
 import { BASE_URL } from "../lib/config";
@@ -102,19 +96,7 @@ export default function PostInput({ onPost }: Props) {
         <div className="flex items-center justify-between mt-2">
           <div className="flex gap-4 text-gray-400">
             <button type="button" onClick={triggerFileInput} aria-label="Add image">
-              <PhotoIcon className="w-6 h-6 hover:text-brand" />
-            </button>
-            <button type="button" aria-label="Add emoji">
-              <FaceSmileIcon className="w-6 h-6 hover:text-brand" />
-            </button>
-            <button type="button" aria-label="Add poll">
-              <ChartBarIcon className="w-6 h-6 hover:text-brand" />
-            </button>
-            <button type="button" aria-label="Schedule">
-              <CalendarIcon className="w-6 h-6 hover:text-brand" />
-            </button>
-            <button type="button" aria-label="Add location">
-              <MapPinIcon className="w-6 h-6 hover:text-brand" />
+              <PhotoIcon className="w-6 h-6 icon-hover-brand" />
             </button>
           </div>
           <button

--- a/src/app/components/Timeline.tsx
+++ b/src/app/components/Timeline.tsx
@@ -18,7 +18,7 @@ const Timeline: React.FC<TimelineProps> = ({ posts = [] }) => {
     return (
         <div className="relative container mx-auto px-4 py-8">
             {/* Vertical line */}
-            <div className="absolute left-6 top-0 bottom-0 w-1 bg-[#0055FF]" />
+            <div className="absolute left-6 top-0 bottom-0 w-1 bg-brand" />
 
             <ul className="space-y-12 relative">
                 {posts.map((post, index) => (
@@ -32,7 +32,7 @@ const Timeline: React.FC<TimelineProps> = ({ posts = [] }) => {
                     >
                         {/* Icon container */}
                         <div className="flex-shrink-0 relative z-10">
-                            <div className="w-12 h-12 flex items-center justify-center bg-[#0055FF] text-white rounded-md shadow-lg">
+                            <div className="w-12 h-12 flex items-center justify-center bg-brand text-white rounded-md shadow-lg">
                                 {post.imageUrl ? (
                                     <Image
                                         src={post.imageUrl}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -100,3 +100,9 @@ div {
 .animate-pulse div {
     animation: pulse 1.5s ease-in-out infinite;
 }
+
+/* Brand color hover utility */
+.icon-hover-brand:hover {
+    color: var(--brand-color);
+    fill: var(--brand-color);
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -64,7 +64,7 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
     return (
         <html lang="mn" className="dark">
-            <body className={`${inter.className} flex flex-col min-h-screen bg-secondary text-white`}>
+            <body className={`${inter.className} flex flex-col min-h-screen bg-surface text-primary`}>
                 <LayoutClient>{children}</LayoutClient>
             </body>
         </html>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -556,13 +556,13 @@ export default function HomePage() {
                         whileTap={{ scale: 0.8 }}
                         onClick={() => handleLike(post._id)}
                         disabled={!loggedIn}
-                        className="flex items-center justify-center gap-1 hover:text-gray-800"
+                        className="flex items-center justify-center gap-1 hover:text-brand"
                         aria-label={`Like (${post.likes.length})`}
                       >
                         {likedPosts.includes(post._id) ? (
-                          <HeartSolid className="w-4 h-4 text-red-500" />
+                          <HeartSolid className="w-4 h-4 text-brand icon-hover-brand" />
                         ) : (
-                          <HeartOutline className="w-4 h-4" />
+                          <HeartOutline className="w-4 h-4 icon-hover-brand" />
                         )}
                         <span>{post.likes.length}</span>
                       </motion.button>
@@ -571,10 +571,10 @@ export default function HomePage() {
                       <button
                         onClick={() => toggleComments(post._id)}
                         disabled={!loggedIn}
-                        className="flex items-center justify-center gap-1 hover:text-gray-800"
+                        className="flex items-center justify-center gap-1 hover:text-brand"
                         aria-label={`Comment (${post.comments?.length || 0})`}
                       >
-                        <ChatBubbleOvalLeftIcon className="w-4 h-4" />
+                        <ChatBubbleOvalLeftIcon className="w-4 h-4 icon-hover-brand" />
                         <span>{post.comments?.length || 0}</span>
                       </button>
 
@@ -583,12 +583,12 @@ export default function HomePage() {
                         whileTap={{ scale: 0.8 }}
                         onClick={() => handleShare(post._id)}
                         disabled={!loggedIn}
-                        className="flex items-center justify-center gap-1 hover:text-gray-800"
+                        className="flex items-center justify-center gap-1 hover:text-brand"
                         aria-label={`Share (${post.shares || 0})`}
                       >
                         <ArrowUpTrayIcon
                           className={`w-4 h-4 ${
-                            sharedPosts.includes(post._id) ? "text-green-500" : ""
+                            sharedPosts.includes(post._id) ? "text-brand icon-hover-brand" : "icon-hover-brand"
                           }`}
                         />
                         <span>{post.shares || 0}</span>

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -1,10 +1,11 @@
 "use client";
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useRef } from "react";
 import axios from "axios";
 import { useRouter } from "next/navigation";
 import Image from "next/image";
 import Link from "next/link";
 import { FaCheckCircle } from "react-icons/fa";
+import { CameraIcon } from "@heroicons/react/24/solid";
 import PostCard from "../components/PostCard";
 import { BASE_URL } from "../lib/config";
 import { getImageUrl } from "../lib/getImageUrl";
@@ -30,6 +31,8 @@ export default function MyOwnProfilePage() {
     const [loadingProfile, setLoadingProfile] = useState(true);
     const [loadingPosts, setLoadingPosts] = useState(false);
     const [error, setError] = useState("");
+    const avatarInputRef = useRef<HTMLInputElement>(null);
+    const coverInputRef = useRef<HTMLInputElement>(null);
 
     const getToken = () => typeof window !== "undefined" ? localStorage.getItem("token") || "" : "";
 
@@ -48,6 +51,44 @@ export default function MyOwnProfilePage() {
 
     const handleShareAdd = (newPost: Post) => {
         setUserPosts((prev) => [newPost, ...prev]);
+    };
+
+    const handleProfilePictureChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+        const file = e.target.files?.[0];
+        if (!file) return;
+        const token = getToken();
+        if (!token) return;
+        const formData = new FormData();
+        formData.append("profilePicture", file);
+        try {
+            const { data } = await axios.put(`${BASE_URL}/api/users/me`, formData, {
+                headers: { Authorization: `Bearer ${token}` },
+            });
+            if (data.profilePicture) {
+                setUserData((prev) => prev ? { ...prev, profilePicture: data.profilePicture } : prev);
+            }
+        } catch (err) {
+            console.error("Profile picture update error", err);
+        }
+    };
+
+    const handleCoverChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+        const file = e.target.files?.[0];
+        if (!file) return;
+        const token = getToken();
+        if (!token) return;
+        const formData = new FormData();
+        formData.append("coverImage", file);
+        try {
+            const { data } = await axios.put(`${BASE_URL}/api/users/me`, formData, {
+                headers: { Authorization: `Bearer ${token}` },
+            });
+            if (data.coverImage) {
+                setUserData((prev) => prev ? { ...prev, coverImage: data.coverImage } : prev);
+            }
+        } catch (err) {
+            console.error("Cover image update error", err);
+        }
     };
 
     // Fetch the logged-in user's profile
@@ -131,7 +172,7 @@ export default function MyOwnProfilePage() {
             </div>
 
             {/* Banner */}
-            <div className="h-40 bg-[#0d0d0d] relative mt-12">
+            <div className="h-40 bg-[#0d0d0d] relative mt-12 group">
                 {userData.coverImage && (
                     <Image
                         src={getImageUrl(userData.coverImage)}
@@ -141,16 +182,44 @@ export default function MyOwnProfilePage() {
                         className="absolute inset-0 w-full h-full object-cover"
                     />
                 )}
-                <div className="absolute -bottom-16 left-4 w-32 h-32 rounded-full border-4 border-[#0d0d0d] overflow-hidden bg-gray-200">
+                <input
+                    ref={coverInputRef}
+                    type="file"
+                    accept="image/*"
+                    className="hidden"
+                    onChange={handleCoverChange}
+                />
+                <button
+                    onClick={() => coverInputRef.current?.click()}
+                    className="absolute inset-0 flex items-center justify-center bg-black/40 opacity-0 group-hover:opacity-100 transition"
+                    aria-label="Change cover"
+                >
+                    <CameraIcon className="w-6 h-6 text-white" />
+                </button>
+                <div className="absolute -bottom-16 left-4 w-32 h-32 rounded-full border-4 border-[#0d0d0d] overflow-hidden bg-gray-200 group">
                     {userData.profilePicture ? (
-                    <Image
-                        src={getImageUrl(userData.profilePicture)}
-                        alt="avatar"
-                        width={128}
-                        height={128}
-                        className="w-full h-full object-cover"
-                    />
+                        <Image
+                            src={getImageUrl(userData.profilePicture)}
+                            alt="avatar"
+                            width={128}
+                            height={128}
+                            className="w-full h-full object-cover"
+                        />
                     ) : null}
+                    <input
+                        ref={avatarInputRef}
+                        type="file"
+                        accept="image/*"
+                        className="hidden"
+                        onChange={handleProfilePictureChange}
+                    />
+                    <button
+                        onClick={() => avatarInputRef.current?.click()}
+                        className="absolute inset-0 flex items-center justify-center bg-black/40 opacity-0 group-hover:opacity-100 transition"
+                        aria-label="Change avatar"
+                    >
+                        <CameraIcon className="w-5 h-5 text-white" />
+                    </button>
                 </div>
             </div>
 


### PR DESCRIPTION
## Summary
- refine brand color usage across buttons and icons
- simplify post input UI
- enable hover icons with brand color
- allow profile picture and cover editing directly in profile page
- adjust layout background styles

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c47d0454c8328ba892b2b25442531