### PR TITLE
Add basic real-time chat feature

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "concurrently \"npm run frontend\" \"npm run server-dev\" \"npm run live-dev\"",
+    "dev": "concurrently \"npm run frontend\" \"npm run server-dev\" \"npm run live-dev\" \"npm run chat-dev\"",
     "frontend": "next dev",
     "server": "node server/index.js",
     "server-dev": "nodemon server/index.js",
@@ -15,7 +15,9 @@
     "mongo-test": "node mongo-test.mjs",
     "live": "node server/live.js",
     "live-dev": "nodemon server/live.js",
-    "live-mongo": "node server/live-mongo.js"
+    "live-mongo": "node server/live-mongo.js",
+    "chat": "node server/chat.js",
+    "chat-dev": "nodemon server/chat.js"
   },
   "dependencies": {
     "@emotion/react": "^11.14.0",

--- a/server/chat.js
+++ b/server/chat.js
@@ -1,0 +1,43 @@
+const path = require('path');
+require('dotenv').config({ path: path.join(__dirname, '.env') });
+const { createServer } = require('http');
+const express = require('express');
+const { Server } = require('socket.io');
+const mongoose = require('mongoose');
+const ChatMessage = require('./models/ChatMessage');
+
+const app = express();
+const http = createServer(app);
+const io = new Server(http, { cors: { origin: '*' } });
+
+const mongoUri = process.env.MONGODB_URI;
+if (!mongoUri) {
+  console.error('Missing MONGODB_URI');
+  process.exit(1);
+}
+
+mongoose
+  .connect(mongoUri)
+  .then(() => console.log('Connected to MongoDB for chat'))
+  .catch(err => {
+    console.error('MongoDB connection error', err);
+    process.exit(1);
+  });
+
+io.on('connection', socket => {
+  socket.on('join', room => socket.join(room));
+
+  socket.on('chat-message', async ({ room, text, sender }) => {
+    if (!room || !text || !sender) return;
+    try {
+      const msg = await ChatMessage.create({ room, text, sender });
+      const full = await msg.populate('sender', 'username profilePicture');
+      io.to(room).emit('chat-message', full);
+    } catch (err) {
+      console.error('Chat message error', err);
+    }
+  });
+});
+
+const PORT = process.env.CHAT_PORT || 5003;
+http.listen(PORT, () => console.log('Chat server ' + PORT));

--- a/server/index.js
+++ b/server/index.js
@@ -17,6 +17,7 @@ const productRoutes = require("./routes/productRoutes");
 const cartRoutes    = require("./routes/cartRoutes"); // ← feature branch win
 const notificationRoutes = require("./routes/notification");
 const pushRoutes    = require("./routes/push");const webpush       = require("web-push");
+const chatRoutes    = require("./routes/chat");
 
 const app  = express();
 const PORT = process.env.PORT || 5001;
@@ -80,6 +81,7 @@ app.use("/api/products", productRoutes);
 app.use("/api/cart",     cartRoutes); // ← now live
 app.use("/api/notifications", notificationRoutes);
 app.use("/api/push",     pushRoutes);
+app.use("/api/chat",    chatRoutes);
 
 // ── heartbeat ─────────────────────────────────────────
 app.get("/", (_, res) => res.send("Server is working!"));

--- a/server/models/ChatMessage.js
+++ b/server/models/ChatMessage.js
@@ -1,0 +1,15 @@
+const mongoose = require('mongoose');
+const { Schema, model, models } = mongoose;
+
+const ChatMessageSchema = new Schema(
+  {
+    room: { type: String, required: true },
+    sender: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
+    text: { type: String, required: true },
+    createdAt: { type: Date, default: Date.now }
+  },
+  { timestamps: true }
+);
+
+const ChatMessage = models.ChatMessage || model('ChatMessage', ChatMessageSchema);
+module.exports = ChatMessage;

--- a/server/routes/chat.js
+++ b/server/routes/chat.js
@@ -1,0 +1,21 @@
+const express = require('express');
+const router = express.Router();
+const ChatMessage = require('../models/ChatMessage');
+const authenticateToken = require('../middleware/authMiddleware');
+
+// Fetch last 50 messages for a room
+router.get('/:room', authenticateToken, async (req, res) => {
+  try {
+    const { room } = req.params;
+    const messages = await ChatMessage.find({ room })
+      .sort({ createdAt: -1 })
+      .limit(50)
+      .populate('sender', 'username profilePicture');
+    res.json(messages.reverse());
+  } catch (err) {
+    console.error('Chat fetch error', err);
+    res.status(500).json({ error: 'Failed to fetch messages' });
+  }
+});
+
+module.exports = router;

--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -1,0 +1,56 @@
+"use client";
+import { useState } from "react";
+import useChat from "../hooks/useChat";
+import Image from "next/image";
+
+export default function ChatPage() {
+  const room = "general";
+  const userId = typeof window !== "undefined" ? localStorage.getItem("userId") || "" : "";
+  const { messages, sendMessage } = useChat(room);
+  const [text, setText] = useState("");
+
+  const handleSend = () => {
+    if (text.trim()) {
+      sendMessage(text, userId);
+      setText("");
+    }
+  };
+
+  return (
+    <div className="min-h-screen flex flex-col p-4">
+      <div className="flex-1 overflow-y-auto mb-4">
+        {messages.map((msg) => (
+          <div key={msg._id} className="mb-2 flex items-start">
+            {msg.sender?.profilePicture && (
+              <Image
+                src={msg.sender.profilePicture}
+                alt=""
+                width={32}
+                height={32}
+                className="rounded-full mr-2"
+              />
+            )}
+            <div>
+              <div className="font-semibold">{msg.sender?.username}</div>
+              <div>{msg.text}</div>
+            </div>
+          </div>
+        ))}
+      </div>
+      <div className="flex items-center">
+        <input
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          className="border flex-1 p-2 mr-2 rounded"
+          placeholder="Type a message..."
+        />
+        <button
+          onClick={handleSend}
+          className="px-4 py-2 bg-blue-500 text-white rounded"
+        >
+          Send
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/hooks/useChat.ts
+++ b/src/app/hooks/useChat.ts
@@ -1,0 +1,50 @@
+"use client";
+import { useState, useEffect } from "react";
+import { io, Socket } from "socket.io-client";
+import { CHAT_URL, API_URL } from "../lib/config";
+
+export interface ChatMessage {
+  _id: string;
+  room: string;
+  text: string;
+  createdAt: string;
+  sender: { _id: string; username: string; profilePicture?: string };
+}
+
+let socket: Socket | null = null;
+
+export default function useChat(room: string) {
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+
+  useEffect(() => {
+    const token = typeof window !== "undefined" ? localStorage.getItem("token") || "" : "";
+    fetch(`${API_URL}/chat/${room}`, { headers: { Authorization: `Bearer ${token}` } })
+      .then(res => res.json())
+      .then((data: ChatMessage[]) => setMessages(data))
+      .catch(err => console.error("Fetch messages error", err));
+  }, [room]);
+
+  useEffect(() => {
+    if (!socket) {
+      socket = io(CHAT_URL, { autoConnect: true });
+    }
+
+    socket.emit("join", room);
+    const handler = (msg: ChatMessage) => {
+      if (msg.room === room) {
+        setMessages(m => [...m, msg]);
+      }
+    };
+    socket.on("chat-message", handler);
+    return () => {
+      socket?.off("chat-message", handler);
+    };
+  }, [room]);
+
+  const sendMessage = (text: string, sender: string) => {
+    if (!socket) return;
+    socket.emit("chat-message", { room, text, sender });
+  };
+
+  return { messages, sendMessage };
+}

--- a/src/app/lib/config.ts
+++ b/src/app/lib/config.ts
@@ -3,3 +3,5 @@ export const BASE_URL = API_URL.replace(/\/api$/, '');
 export const UPLOADS_URL = `${BASE_URL}/api/uploads`;
 // Default to localhost Socket.IO server when developing.
 export const LIVE_URL = process.env.NEXT_PUBLIC_LIVE_URL ?? 'http://localhost:5002';
+// Chat Socket.IO server
+export const CHAT_URL = process.env.NEXT_PUBLIC_CHAT_URL ?? 'http://localhost:5003';


### PR DESCRIPTION
## Summary
- create `ChatMessage` model
- add chat REST endpoint and websocket server
- expose new chat URL constant
- implement client hook and page for chat
- wire chat server into API server
- update package scripts

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c5273124083288c75dfebd87061d7