### PR TITLE
Refine news feed style

### DIFF
--- a/src/app/components/PostCard.tsx
+++ b/src/app/components/PostCard.tsx
@@ -140,7 +140,7 @@ export default function PostCard({ post, user, onDelete, onShare }: Props) {
                 >
                   <svg
                     xmlns="http://www.w3.org/2000/svg"
-                    className="w-4 h-4"
+                    className="w-5 h-5"
                     fill="none"
                     viewBox="0 0 24 24"
                     stroke="currentColor"
@@ -201,9 +201,9 @@ export default function PostCard({ post, user, onDelete, onShare }: Props) {
               aria-label="Like"
             >
               {liked ? (
-                <HeartSolid className="w-4 h-4 text-brand icon-hover-brand" />
+                <HeartSolid className="w-5 h-5 text-brand icon-hover-brand" />
               ) : (
-                <HeartOutline className="w-4 h-4 icon-hover-brand" />
+                <HeartOutline className="w-5 h-5 icon-hover-brand" />
               )}
               <span>{likes}</span>
             </motion.button>
@@ -217,7 +217,7 @@ export default function PostCard({ post, user, onDelete, onShare }: Props) {
               aria-label="Share"
             >
               <ArrowUpTrayIcon
-                className={shared ? "w-4 h-4 text-brand icon-hover-brand" : "w-4 h-4 icon-hover-brand"}
+                className={shared ? "w-5 h-5 text-brand icon-hover-brand" : "w-5 h-5 icon-hover-brand"}
               />
               <span>{shares}</span>
             </motion.button>

--- a/src/app/components/PostInput.tsx
+++ b/src/app/components/PostInput.tsx
@@ -2,7 +2,7 @@
 
 import React, { useRef, useState } from "react";
 import Image from "next/image";
-import { PhotoIcon } from "@heroicons/react/24/outline";
+import { PhotoIcon, ChartBarIcon } from "@heroicons/react/24/outline";
 import { useAuth } from "../context/AuthContext";
 import axios from "axios";
 import { BASE_URL } from "../lib/config";
@@ -62,7 +62,7 @@ export default function PostInput({ onPost }: Props) {
   };
 
   return (
-    <div className="flex bg-white rounded-2xl border border-gray-100 shadow-sm p-4 md:p-6 max-w-xl mx-auto">
+    <div className="flex bg-white rounded-xl shadow p-4 m-4 max-w-xl mx-auto">
       {user?.profilePicture ? (
         <Image
           src={`${BASE_URL}${user.profilePicture}`}
@@ -88,21 +88,24 @@ export default function PostInput({ onPost }: Props) {
           onInput={autoResize}
           maxLength={MAX_LENGTH}
           placeholder="What's happening?"
-          className="w-full text-lg font-medium bg-transparent outline-none resize-none min-h-[64px] placeholder-gray-500 focus:border-b focus:border-brand border-b"
+          className="w-full text-xl bg-transparent outline-none resize-none min-h-[72px] placeholder:text-gray-400 placeholder:text-xl"
           rows={1}
           value={content}
           onChange={(e) => setContent(e.target.value)}
         />
         <div className="flex items-center justify-between mt-2">
-          <div className="flex gap-4 text-gray-400">
+          <div className="flex gap-3 text-gray-400">
             <button type="button" onClick={triggerFileInput} aria-label="Add image">
               <PhotoIcon className="w-6 h-6 icon-hover-brand" />
+            </button>
+            <button type="button" aria-label="Add poll">
+              <ChartBarIcon className="w-6 h-6 icon-hover-brand" />
             </button>
           </div>
           <button
             onClick={createPost}
             disabled={posting || (!content.trim() && !imageFile)}
-            className="bg-brand text-white font-bold rounded-full px-6 py-2 disabled:opacity-50"
+            className={`font-bold rounded-full px-6 py-2 transition-all active:scale-95 ${content.trim() || imageFile ? 'bg-brand text-white' : 'bg-gray-300 text-white cursor-not-allowed'}`}
           >
             Post
           </button>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -430,7 +430,7 @@ export default function HomePage() {
                     initial={{ opacity: 0, y: 20 }}
                     animate={{ opacity: 1, y: 0 }}
                     transition={{ delay: idx * 0.02 }}
-                    className="bg-[#2a2a2a] text-white p-6 grid gap-4 border-b border-gray-700"
+                    className="bg-white p-6 grid gap-4 border-b border-gray-200 dark:bg-[#2a2a2a] dark:border-gray-700 dark:text-white"
                   >
                     {/* Header */}
                     <div className="grid grid-cols-[auto,1fr] gap-5 group">
@@ -487,7 +487,7 @@ export default function HomePage() {
                               >
                                 <svg
                                   xmlns="http://www.w3.org/2000/svg"
-                                  className="w-4 h-4"
+                                  className="w-5 h-5"
                                   fill="none"
                                   viewBox="0 0 24 24"
                                   stroke="currentColor"
@@ -560,9 +560,9 @@ export default function HomePage() {
                         aria-label={`Like (${post.likes.length})`}
                       >
                         {likedPosts.includes(post._id) ? (
-                          <HeartSolid className="w-4 h-4 text-brand icon-hover-brand" />
+                          <HeartSolid className="w-5 h-5 text-brand icon-hover-brand" />
                         ) : (
-                          <HeartOutline className="w-4 h-4 icon-hover-brand" />
+                          <HeartOutline className="w-5 h-5 icon-hover-brand" />
                         )}
                         <span>{post.likes.length}</span>
                       </motion.button>
@@ -574,7 +574,7 @@ export default function HomePage() {
                         className="flex items-center justify-center gap-1 hover:text-brand"
                         aria-label={`Comment (${post.comments?.length || 0})`}
                       >
-                        <ChatBubbleOvalLeftIcon className="w-4 h-4 icon-hover-brand" />
+                        <ChatBubbleOvalLeftIcon className="w-5 h-5 icon-hover-brand" />
                         <span>{post.comments?.length || 0}</span>
                       </button>
 
@@ -587,7 +587,7 @@ export default function HomePage() {
                         aria-label={`Share (${post.shares || 0})`}
                       >
                         <ArrowUpTrayIcon
-                          className={`w-4 h-4 ${
+                          className={`w-5 h-5 ${
                             sharedPosts.includes(post._id) ? "text-brand icon-hover-brand" : "icon-hover-brand"
                           }`}
                         />


### PR DESCRIPTION
## Summary
- adjust post styling to match white card design
- enlarge feed and card icons for better readability

## Testing
- `npm test` *(fails: jest not found)*


------
https://chatgpt.com/codex/tasks/task_e_685c5a3e70b08328899337e2ecc001a1