### PR TITLE
Improve classroom mobile UX

### DIFF
--- a/docs/classroom-design.md
+++ b/docs/classroom-design.md
@@ -1,0 +1,31 @@
+# Classroom Page Design Guidelines
+
+This document describes the UX/UI specifications for the `Classroom` page. The goal is to provide a mobile friendly layout and a clear style guide for implementation.
+
+## Layout
+- **Responsive columns**: On `md` screens and above the page uses a two column layout with a sidebar on the left and the lesson content on the right. On small screens the sidebar becomes a slide in panel triggered by a menu button.
+- **Sidebar sizing**: width `w-64` (16rem) on mobile and `w-80` (20rem) for `md` and up.
+- **Spacing**: padding inside the sidebar is `p-6`. Main content has `p-4` on mobile and `p-10` on `md` and above.
+- **Sidebar toggle**: A hamburger button (`Bars3Icon`) positioned `top-2 left-2` opens the sidebar on mobile. A close button (`XMarkIcon`) inside the sidebar at `top-2 right-2` hides it.
+
+## Colors
+- **Brand color**: `#119C99` (`bg-brand` in Tailwind config).
+- **Sidebar borders**: `border-gray-200` on light mode.
+- **Completed state**: green `#22c55e` icons (`text-green-500`) and progress bar (`bg-green-400`).
+- **Selected item**: `bg-cyan-50` background with a left border `border-cyan-400`.
+
+## Typography
+- Base font is Inter (loaded via `next/font`).
+- Heading inside sidebar uses `text-xl` and `font-bold`.
+- Lesson titles use `font-medium` with truncation for long text.
+
+## Interactive Behaviors
+- **Hover**: lesson items slightly change background (`bg-yellow-50` default). Hover uses the `tesla-hover` utility which adds a subtle scale and overlay.
+- **Focus**: buttons and inputs rely on Tailwind's default focus styles; ensure `focus:outline-none focus:ring-2 focus:ring-brand` when creating new UI elements.
+- **Mobile sidebar**: tapping outside the panel closes it. The panel slides in/out using Tailwind `transition-transform`.
+
+## Platform Notes
+- Works with Tailwind CSS and Next.js client components.
+- Dark mode is supported via the global `.dark` class. Sidebar and text automatically adapt using existing CSS variables.
+
+These guidelines should keep the classroom page visually consistent across screen sizes while solving the previous issue of the sidebar not displaying on mobile.

--- a/src/app/classroom/page.tsx
+++ b/src/app/classroom/page.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-import { CheckIcon } from '@heroicons/react/24/outline';
-import { AcademicCapIcon, PencilSquareIcon, TrashIcon } from '@heroicons/react/24/solid';
+import { CheckIcon, Bars3Icon, XMarkIcon } from '@heroicons/react/24/outline';
+import { BookOpenIcon, PencilSquareIcon, TrashIcon } from '@heroicons/react/24/solid';
 import { useAuth } from '../context/AuthContext';
 
 interface Lesson {
@@ -31,6 +31,7 @@ export default function ClassroomPage() {
   const [newUrl, setNewUrl] = useState('');
   const [newDesc, setNewDesc] = useState('');
   const [editingId, setEditingId] = useState<number | null>(null);
+  const [sidebarOpen, setSidebarOpen] = useState(false);
 
   useEffect(() => {
     const stored = localStorage.getItem('lessons');
@@ -108,10 +109,32 @@ export default function ClassroomPage() {
     : 0;
 
   return (
-    <div className="flex flex-col md:flex-row h-full w-full min-h-screen">
-      <aside className="w-full md:w-80 md:min-w-64 bg-white p-6 flex flex-col border-b md:border-b-0 md:border-r border-gray-200 text-black overflow-y-auto md:h-screen md:sticky md:top-0">
+    <div className="flex flex-col md:flex-row h-full w-full min-h-screen relative">
+      <button
+        className="md:hidden absolute top-2 left-2 z-20 p-2 bg-white rounded-full shadow"
+        onClick={() => setSidebarOpen(true)}
+        aria-label="Open lessons"
+      >
+        <Bars3Icon className="w-6 h-6 text-gray-600" />
+      </button>
+      {sidebarOpen && (
+        <div
+          className="fixed inset-0 bg-black bg-opacity-40 z-10 md:hidden"
+          onClick={() => setSidebarOpen(false)}
+        />
+      )}
+      <aside
+        className={`bg-white p-6 flex flex-col border-b md:border-b-0 md:border-r border-gray-200 text-black overflow-y-auto md:h-screen md:sticky md:top-0 fixed md:relative inset-y-0 left-0 z-20 w-64 md:w-80 md:min-w-64 transform transition-transform ${sidebarOpen ? 'translate-x-0' : '-translate-x-full md:translate-x-0'}`}
+      >
+        <button
+          className="md:hidden absolute top-2 right-2 p-1"
+          onClick={() => setSidebarOpen(false)}
+          aria-label="Close lessons"
+        >
+          <XMarkIcon className="w-5 h-5 text-gray-600" />
+        </button>
         <h2 className="text-xl font-bold mb-4 flex items-center gap-2">
-          <AcademicCapIcon className="w-6 h-6" /> Classroom
+          <BookOpenIcon className="w-6 h-6" /> Classroom
         </h2>
         <div className="flex items-center mb-2">
           <div className="flex-1 h-2 bg-gray-200 rounded">


### PR DESCRIPTION
## Summary
- make classroom sidebar responsive with a mobile toggle
- change the header icon to `BookOpenIcon`
- document design guidelines for the classroom page

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c6471a6648328ac586ccadccbf49d