### PR TITLE
Implement auth middleware and navigation updates

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+
+export function middleware(request: NextRequest) {
+  const token = request.cookies.get('token')?.value;
+  const publicPaths = ['/login', '/register'];
+
+  if (!token && !publicPaths.some((p) => request.nextUrl.pathname.startsWith(p))) {
+    const loginUrl = new URL('/login', request.url);
+    return NextResponse.redirect(loginUrl);
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ['/((?!_next/|favicon.ico|public|uploads).*)'],
+};

--- a/src/app/components/BottomNav.tsx
+++ b/src/app/components/BottomNav.tsx
@@ -7,6 +7,7 @@ import {
     PlusCircleIcon,
     BellIcon,
     AcademicCapIcon,
+    ChatBubbleLeftRightIcon,
 } from "@heroicons/react/24/outline";
 import AddPostModal from "./AddPostModal";
 import { useNotifications } from "../context/NotificationContext";
@@ -36,8 +37,8 @@ const BottomNav: React.FC = () => {
     return (
         <>
         <nav
-            className={`fixed bottom-0 left-0 w-full md:hidden transition-all backdrop-blur-xl border-t border-supportBorder shadow-lg ${
-                scrolledDown ? "bg-gradient-to-br from-white/40 via-white/20 to-white/10" : "bg-gradient-to-br from-white/30 via-white/10 to-white/5"
+            className={`fixed bottom-0 left-0 w-full md:hidden transition-all border-t border-supportBorder shadow-lg bg-surface ${
+                scrolledDown ? "" : ""
             }`}
         >
             <div
@@ -73,6 +74,15 @@ const BottomNav: React.FC = () => {
                             {unreadCount}
                         </span>
                     )}
+                </button>
+
+                {/* CHAT */}
+                <button
+                    onClick={() => router.push("/chat")}
+                    aria-label="Chat"
+                    className="p-1 text-black hover:text-brand"
+                >
+                    <ChatBubbleLeftRightIcon className="h-7 w-7 icon-hover-brand" />
                 </button>
 
                 {/* CLASSROOM */}

--- a/src/app/components/Header.tsx
+++ b/src/app/components/Header.tsx
@@ -3,6 +3,13 @@ import React, { useState } from "react";
 import Link from "next/link";
 import Image from "next/image";
 import { UserCircleIcon } from "@heroicons/react/24/solid";
+import {
+    HomeIcon,
+    UserGroupIcon,
+    AcademicCapIcon,
+    BellIcon,
+    ChatBubbleLeftRightIcon,
+} from "@heroicons/react/24/outline";
 import { useAuth } from "../context/AuthContext";
 import { BASE_URL } from "../lib/config";
 
@@ -195,20 +202,7 @@ export default function Header() {
                                             onClick={() => setIsMenuOpen(false)}
                                             className="flex items-center gap-2 hover:text-brand"
                                         >
-                                            <svg
-                                                xmlns="http://www.w3.org/2000/svg"
-                                                className="w-6 h-6"
-                                                fill="none"
-                                                viewBox="0 0 24 24"
-                                                stroke="currentColor"
-                                            >
-                                                <path
-                                                    strokeLinecap="round"
-                                                    strokeLinejoin="round"
-                                                    strokeWidth="2"
-                                                    d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6"
-                                                />
-                                            </svg>
+                                            <HomeIcon className="w-6 h-6" />
                                             Нүүр
                                         </Link>
                                     </li>
@@ -243,20 +237,7 @@ export default function Header() {
                                             onClick={() => setIsMenuOpen(false)}
                                             className="flex items-center gap-2 hover:text-brand"
                                         >
-                                            <svg
-                                                xmlns="http://www.w3.org/2000/svg"
-                                                className="w-6 h-6"
-                                                fill="none"
-                                                viewBox="0 0 24 24"
-                                                stroke="currentColor"
-                                            >
-                                                <path
-                                                    strokeLinecap="round"
-                                                    strokeLinejoin="round"
-                                                    strokeWidth="2"
-                                                    d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"
-                                                />
-                                            </svg>
+                                            <UserGroupIcon className="w-6 h-6" />
                                             Гишүүд
                                         </Link>
                                     </li>
@@ -266,21 +247,28 @@ export default function Header() {
                                             onClick={() => setIsMenuOpen(false)}
                                             className="flex items-center gap-2 hover:text-brand"
                                         >
-                                            <svg
-                                                xmlns="http://www.w3.org/2000/svg"
-                                                className="w-6 h-6"
-                                                fill="none"
-                                                viewBox="0 0 24 24"
-                                                stroke="currentColor"
-                                            >
-                                                <path
-                                                    strokeLinecap="round"
-                                                    strokeLinejoin="round"
-                                                    strokeWidth="2"
-                                                    d="M12 14l9-5-9-5-9 5 9 5zm0 0v6"
-                                                />
-                                            </svg>
-                                            Classroom
+                                            <AcademicCapIcon className="w-6 h-6" />
+                                            Хичээл
+                                        </Link>
+                                    </li>
+                                    <li>
+                                        <Link
+                                            href="/notifications"
+                                            onClick={() => setIsMenuOpen(false)}
+                                            className="flex items-center gap-2 hover:text-brand"
+                                        >
+                                            <BellIcon className="w-6 h-6" />
+                                            Мэдүүлэл
+                                        </Link>
+                                    </li>
+                                    <li>
+                                        <Link
+                                            href="/chat"
+                                            onClick={() => setIsMenuOpen(false)}
+                                            className="flex items-center gap-2 hover:text-brand"
+                                        >
+                                            <ChatBubbleLeftRightIcon className="w-6 h-6" />
+                                            Чат
                                         </Link>
                                     </li>
                                 </ul>

--- a/src/app/components/LayoutClient.tsx
+++ b/src/app/components/LayoutClient.tsx
@@ -6,7 +6,13 @@ import { AuthProvider } from "../context/AuthContext";
 import { CartProvider } from "../context/CartContext";
 import { ThemeProvider } from "../context/ThemeContext";
 import { NotificationProvider, useNotifications } from "../context/NotificationContext";
-import { BellIcon } from "@heroicons/react/24/outline";
+import {
+  BellIcon,
+  HomeIcon,
+  UserGroupIcon,
+  AcademicCapIcon,
+  ChatBubbleLeftRightIcon,
+} from "@heroicons/react/24/outline";
 import Header from "./Header";
 import TopActiveMembers from "./TopActiveMembers";
 import BottomNav from "./BottomNav";
@@ -73,20 +79,7 @@ export default function LayoutClient({ children }: { children: React.ReactNode }
                         href="/"
                         className="group flex items-center gap-2 p-4 pl-0 text-xl font-semibold text-gray-700 transition-smooth focus:outline-none hover:text-brand focus:ring-2 focus:ring-brand"
                       >
-                        <svg
-                          xmlns="http://www.w3.org/2000/svg"
-                          className="w-6 h-6 group-hover:text-brand"
-                          fill="none"
-                          viewBox="0 0 24 24"
-                          stroke="currentColor"
-                        >
-                          <path
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                            strokeWidth="2"
-                            d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6"
-                          />
-                        </svg>
+                        <HomeIcon className="w-6 h-6 group-hover:text-brand" />
                         <span>Нүүр</span>
                       </Link>
                     </li>
@@ -95,15 +88,7 @@ export default function LayoutClient({ children }: { children: React.ReactNode }
                       href="/users"
                       className="group flex items-center gap-2 p-4 pl-0 text-xl font-semibold text-gray-700 transition-smooth focus:outline-none hover:text-brand focus:ring-2 focus:ring-brand"
                     >
-                      <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        className="w-6 h-6 group-hover:text-brand"
-                        fill="none"
-                        viewBox="0 0 24 24"
-                        stroke="currentColor"
-                      >
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
-                      </svg>
+                      <UserGroupIcon className="w-6 h-6 group-hover:text-brand" />
                       <span>Гишүүд</span>
                     </Link>
                   </li>
@@ -112,19 +97,20 @@ export default function LayoutClient({ children }: { children: React.ReactNode }
                       href="/classroom"
                       className="group flex items-center gap-2 p-4 pl-0 text-xl font-semibold text-gray-700 transition-smooth focus:outline-none hover:text-brand focus:ring-2 focus:ring-brand"
                     >
-                      <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        className="w-6 h-6 group-hover:text-brand"
-                        fill="none"
-                        viewBox="0 0 24 24"
-                        stroke="currentColor"
-                      >
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 14l9-5-9-5-9 5 9 5zm0 0v6" />
-                      </svg>
-                  <span>Classroom</span>
+                      <AcademicCapIcon className="w-6 h-6 group-hover:text-brand" />
+                  <span>Хичээл</span>
                     </Link>
                   </li>
                   <NotificationNavItem />
+                  <li>
+                    <Link
+                      href="/chat"
+                      className="group flex items-center gap-2 p-4 pl-0 text-xl font-semibold text-gray-700 transition-smooth focus:outline-none hover:text-brand focus:ring-2 focus:ring-brand"
+                    >
+                      <ChatBubbleLeftRightIcon className="w-6 h-6 group-hover:text-brand" />
+                      <span>Чат</span>
+                    </Link>
+                  </li>
                   </ul>
                 </nav>
               </aside>

--- a/src/app/context/AuthContext.tsx
+++ b/src/app/context/AuthContext.tsx
@@ -79,6 +79,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         };
         localStorage.setItem("user", JSON.stringify(userWithSubscription));
         localStorage.setItem("token", token);
+        document.cookie = `token=${token}; path=/`;
         setUser(userWithSubscription);
         setLoggedIn(true);
     };
@@ -86,6 +87,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     const logout = () => {
         localStorage.removeItem("user");
         localStorage.removeItem("token");
+        document.cookie = "token=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT";
         setUser(null);
         setLoggedIn(false);
     };

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 import React, { useState, useEffect } from "react";
+import { motion } from "framer-motion";
 import axios from "axios";
 import { useRouter } from "next/navigation";
 import { useAuth } from "@/app/context/AuthContext";
@@ -39,6 +40,7 @@ export default function LoginPage() {
             if (res.status === 200 && res.data.token) {
                 const { user, token } = res.data;
                 login(user, token);
+                document.cookie = `token=${token}; path=/`;
                 if (remember) {
                     localStorage.setItem("rememberUsername", username);
                     localStorage.setItem("rememberPassword", password);
@@ -56,7 +58,12 @@ export default function LoginPage() {
 
     return (
         <div className="min-h-screen bg-white text-black flex items-center justify-center px-4">
-            <div className="w-full max-w-md space-y-6">
+            <motion.div
+                whileHover={{ opacity: 0.9 }}
+                transition={{ duration: 0.1, ease: "easeOut" }}
+                className="w-full max-w-md space-y-6"
+            >
+                <p className="text-center mb-10">AI Social Network Манай Network нэмэгдсэнээр хамгийн сүүлийн үеийн мэдээллэл AI skills эзэмшинэ</p>
                 <h1 className="text-3xl font-bold text-black">Нэвтрэх</h1>
                 {error && <p className="text-red-600">{error}</p>}
                 <form onSubmit={handleSubmit} className="space-y-6">
@@ -117,7 +124,7 @@ export default function LoginPage() {
                 >
                     Бүртгүүлэх
                 </button>
-            </div>
+            </motion.div>
         </div>
     );
 }


### PR DESCRIPTION
## Summary
- add middleware to require auth and redirect to `/login`
- set auth token cookie on login and clear on logout
- enhance login page text and motion effect
- update sidebar and mobile navigation icons and add chat link
- update bottom nav style and add chat

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c6dd40fd48328ae5d4981854638cf