### PR TITLE
Refine styles and remove sidebar members

### DIFF
--- a/src/app/classroom/page.tsx
+++ b/src/app/classroom/page.tsx
@@ -149,7 +149,7 @@ export default function ClassroomPage() {
           {lessons.map((lesson) => (
             <li
               key={lesson.id}
-              className={`flex items-center px-3 py-2 rounded cursor-pointer mb-1 ${lesson.completed ? 'bg-green-50' : 'bg-yellow-50'} ${selected && selected.id === lesson.id ? 'border-l-4 border-cyan-400 bg-cyan-50' : ''}`}
+              className={`flex items-center px-3 py-2 rounded cursor-pointer mb-1 ${lesson.completed ? 'bg-green-50' : 'bg-brand/10'} ${selected && selected.id === lesson.id ? 'border-l-4 border-cyan-400 bg-cyan-50' : ''}`}
               onClick={() => setSelected(lesson)}
             >
               <CheckIcon

--- a/src/app/components/BottomNav.tsx
+++ b/src/app/components/BottomNav.tsx
@@ -37,7 +37,7 @@ const BottomNav: React.FC = () => {
     return (
         <>
         <nav
-            className={`fixed bottom-0 left-0 w-full md:hidden transition-all border-t border-supportBorder shadow-lg bg-surface ${
+            className={`fixed bottom-0 left-0 w-full md:hidden transition-all border-t border-supportBorder shadow-lg bg-[#212121] text-white ${
                 scrolledDown ? "" : ""
             }`}
         >
@@ -48,7 +48,7 @@ const BottomNav: React.FC = () => {
                 <button
                     onClick={() => router.push("/")}
                     aria-label="Home"
-                    className="p-1 text-black hover:text-brand"
+                    className="p-1 text-white hover:text-brand"
                 >
                     <HomeIcon className="h-7 w-7 icon-hover-brand" />
                 </button>
@@ -57,7 +57,7 @@ const BottomNav: React.FC = () => {
                 <button
                     onClick={() => setShowModal(true)}
                     aria-label="New Post"
-                    className="p-1 text-black hover:text-brand"
+                    className="p-1 text-white hover:text-brand"
                 >
                     <PlusCircleIcon className="h-8 w-8 icon-hover-brand" />
                 </button>
@@ -66,7 +66,7 @@ const BottomNav: React.FC = () => {
                 <button
                     onClick={() => router.push("/notifications")}
                     aria-label="Notifications"
-                    className="relative p-1 text-black hover:text-brand"
+                    className="relative p-1 text-white hover:text-brand"
                 >
                     <BellIcon className="h-7 w-7 icon-hover-brand" />
                     {unreadCount > 0 && (
@@ -80,7 +80,7 @@ const BottomNav: React.FC = () => {
                 <button
                     onClick={() => router.push("/chat")}
                     aria-label="Chat"
-                    className="p-1 text-black hover:text-brand"
+                    className="p-1 text-white hover:text-brand"
                 >
                     <ChatBubbleLeftRightIcon className="h-7 w-7 icon-hover-brand" />
                 </button>
@@ -89,7 +89,7 @@ const BottomNav: React.FC = () => {
                 <button
                     onClick={() => router.push("/classroom")}
                     aria-label="Classroom"
-                    className="p-1 text-black hover:text-brand"
+                    className="p-1 text-white hover:text-brand"
                 >
                     <AcademicCapIcon className="h-7 w-7 icon-hover-brand" />
                 </button>

--- a/src/app/components/BuyButton.tsx
+++ b/src/app/components/BuyButton.tsx
@@ -41,7 +41,7 @@ export default function BuyButton({ bookId, finalPrice }: BuyButtonProps) {
                         </h2>
                         <p className="text-sm text-gray-300 mb-4">
                             Та {finalPrice.toLocaleString("mn-MN")}₮‐ийг Голомт банк
-                            <span className="text-yellow-400 font-bold"> 3005127815 </span>
+                            <span className="text-brand font-bold"> 3005127815 </span>
                             руу шилжүүлнэ үү. Утга дээр имэйл хаягаа бичээрэй!
                         </p>
                         <p className="text-sm text-gray-400 mb-2">

--- a/src/app/components/Header.tsx
+++ b/src/app/components/Header.tsx
@@ -57,7 +57,7 @@ export default function Header() {
                             </Link>
                         ) : (
                             <Link href="/login" aria-label="Login">
-                                <UserCircleIcon className="w-8 h-8 text-yellow-400" />
+                                <UserCircleIcon className="w-8 h-8 text-brand" />
                             </Link>
                         )}
                         <div className="hidden md:flex items-center space-x-8 font-medium">
@@ -91,7 +91,7 @@ export default function Header() {
                                 </Link>
                                 <Link
                                     href="/register"
-                                    className="relative group text-gray-700 hover:text-brand bg-yellow-300 text-black px-2 rounded"
+                                    className="relative group text-gray-700 hover:text-brand bg-brand text-white px-2 rounded"
                                 >
                                     Бүртгүүлэх
                                     <span className="absolute left-0 bottom-0 w-full h-0.5 bg-brand scale-x-0 group-hover:scale-x-100 transition-transform origin-left" />
@@ -184,7 +184,7 @@ export default function Header() {
                                             <Link
                                                 href="/register"
                                                 onClick={() => setIsMenuOpen(false)}
-                                                className="block text-xl font-medium text-gray-800 hover:text-brand bg-yellow-300 text-black px-2 rounded"
+                                                className="block text-xl font-medium text-gray-800 hover:text-brand bg-brand text-white px-2 rounded"
                                             >
                                                 Бүртгүүлэх
                                             </Link>

--- a/src/app/components/LayoutClient.tsx
+++ b/src/app/components/LayoutClient.tsx
@@ -14,7 +14,6 @@ import {
   ChatBubbleLeftRightIcon,
 } from "@heroicons/react/24/outline";
 import Header from "./Header";
-import TopActiveMembers from "./TopActiveMembers";
 import BottomNav from "./BottomNav";
 import SidebarControl from "./SidebarControl";
 import NavigationLoader from "./NavigationLoader";
@@ -122,11 +121,7 @@ export default function LayoutClient({ children }: { children: React.ReactNode }
               <aside
                 id="right-sidebar"
                 className="hidden md:block w-full md:w-1/4 sticky top-16 h-[calc(100vh-80px)] overflow-y-auto p-2 fade-in-up"
-              >
-                <div className="space-y-6">
-                  <TopActiveMembers />
-                </div>
-              </aside>
+              ></aside>
             </main>
           </div>
           <BottomNav />

--- a/src/app/components/PostCard.tsx
+++ b/src/app/components/PostCard.tsx
@@ -126,7 +126,7 @@ export default function PostCard({ post, user, onDelete, onShare }: Props) {
         <div className="flex-1">
           <div className="flex items-center gap-1 text-sm">
             <span className="font-bold text-black">{user.username}</span>
-            {isPro && <FaCheckCircle className="text-yellow-400 w-3 h-3" />}
+            {isPro && <FaCheckCircle className="text-brand w-3 h-3" />}
             <span className="text-gray-400 ml-1 text-xs">
               {formatPostDate(post.createdAt)}
             </span>

--- a/src/app/components/ThemeToggle.tsx
+++ b/src/app/components/ThemeToggle.tsx
@@ -11,7 +11,7 @@ export default function ThemeToggle() {
             className="p-2 rounded transition-colors hover:bg-gray-200 dark:hover:bg-gray-700"
         >
             {theme === "dark" ? (
-                <SunIcon className="w-6 h-6 text-yellow-400" />
+                <SunIcon className="w-6 h-6 text-brand" />
             ) : (
                 <MoonIcon className="w-6 h-6 text-gray-800" />
             )}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -23,7 +23,7 @@ html {
     --background-dark: #0F181E;
     --text-primary: #272F36;
     --accent: #FF2C55;
-    --premium: #F7B84B;
+    --premium: #119C99;
     --link: #44B2DF;
 }
 

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -61,9 +61,11 @@ export default function LoginPage() {
             <motion.div
                 whileHover={{ opacity: 0.9 }}
                 transition={{ duration: 0.1, ease: "easeOut" }}
-                className="w-full max-w-md space-y-6"
+                className="w-full max-w-md space-y-6 bg-surface p-6 rounded-lg shadow"
             >
-                <p className="text-center mb-10">AI Social Network Манай Network нэмэгдсэнээр хамгийн сүүлийн үеийн мэдээллэл AI skills эзэмшинэ</p>
+                <p className="text-center mb-8 text-xl text-brand font-semibold tracking-wider">
+                    AI Social Network – AI мэдлэгийг овсгоотой эзэмш
+                </p>
                 <h1 className="text-3xl font-bold text-black">Нэвтрэх</h1>
                 {error && <p className="text-red-600">{error}</p>}
                 <form onSubmit={handleSubmit} className="space-y-6">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -357,7 +357,7 @@ export default function HomePage() {
     <div className="min-h-screen bg-secondary text-white">
       {/* Membership banner */}
       {loggedIn && !isPro && (
-        <div className="bg-yellow-500 text-white text-center py-2 px-4">
+        <div className="bg-brand text-white text-center py-2 px-4">
           <Link href="/subscription" className="font-semibold underline">
             Гишүүн болох – Онцгой боломжуудыг нээх
           </Link>
@@ -386,7 +386,7 @@ export default function HomePage() {
               </Link>
               <Link
                 href="/register"
-                className="block bg-yellow-300 text-black px-3 py-1 rounded w-fit mx-auto"
+                className="block bg-brand text-white px-3 py-1 rounded w-fit mx-auto"
               >
                 Бүртгүүлэх
               </Link>

--- a/src/app/profile/[id]/page.tsx
+++ b/src/app/profile/[id]/page.tsx
@@ -137,7 +137,7 @@ export default function PublicProfilePage() {
             <div className="pt-20 px-4">
                 <div className="flex items-center gap-2">
                     <h1 className="text-2xl font-bold">{userData.username}</h1>
-                    {isPro && <FaCheckCircle className="text-yellow-400" />}
+                    {isPro && <FaCheckCircle className="text-brand" />}
                 </div>
                 {userData.rating && (
                     <p className="text-sm text-gray-400">

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -227,7 +227,7 @@ export default function MyOwnProfilePage() {
             <div className="pt-20 px-4">
                 <div className="flex items-center gap-2">
                     <h2 className="text-2xl font-bold">{userData.username}</h2>
-                    {isPro && <FaCheckCircle className="text-yellow-400" />}
+                    {isPro && <FaCheckCircle className="text-brand" />}
                 </div>
                 {userData.rating && <p className="text-sm text-gray-400">★ {userData.rating} үнэлгээ</p>}
                 {userData.location && <p className="text-sm text-gray-400">Байршил: {userData.location}</p>}

--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -239,7 +239,7 @@ export default function RegisterMultiStepPage() {
 
     return (
         <div className="min-h-screen bg-white text-black flex items-center justify-center px-4">
-            <div className="w-full max-w-md space-y-6">
+            <div className="w-full max-w-md space-y-6 bg-surface p-6 rounded-lg shadow">
                 {error && <p className="text-red-600">{error}</p>}
                 {success && <p className="text-green-600">{success}</p>}
 

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -13,7 +13,7 @@ module.exports = {
         surface: '#F5F6F8',
         textPrimary: '#272F36',
         accent: '#FF2C55',
-        premium: '#F7B84B',
+        premium: '#119C99',
         link: '#44B2DF',
         supportBorder: '#272F36',
         primary: '#212121',


### PR DESCRIPTION
## Summary
- tweak bottom nav for dark background and white icons
- modernize login/register layout and tagline
- remove TopActiveMembers sidebar
- shift brand palette to `#119C99`
- update various components to use brand color

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c71f1c77c8328941bbdaa9b0ccd18