### PR TITLE
Add mp3 downloader front-end

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,3 +83,15 @@ Next.js-ийн талаар илүү ихийг дараах эх сурвалж
 Next.js апп-аа байрлуулах хамгийн хялбар арга бол Next.js-ийн бүтээгчдийн санал болгодог [Vercel Платформ](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme)-ыг ашиглах юм.
 
 Дэлгэрэнгүйг манай [Next.js байршуулалтын баримтаас](https://nextjs.org/docs/app/building-your-application/deploying) үзнэ үү.
+
+## MP3 татагч
+
+YouTube линкээс MP3 татахын тулд дараах командыг ашиглана:
+
+```bash
+npm run download-mp3 -- <youtube-ийн-url>
+```
+
+Үүний үр дүнд MP3 файл `tools/mp3` хавтсанд үүснэ.
+
+Мөн хялбар формоор татахыг хүсвэл [http://localhost:3000/tools/mp3](http://localhost:3000/tools/mp3) хуудаснаас линкээ оруулж татаж болно.

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "live-dev": "nodemon server/live.js",
     "live-mongo": "node server/live-mongo.js",
     "chat": "node server/chat.js",
-    "chat-dev": "nodemon server/chat.js"
+    "chat-dev": "nodemon server/chat.js",
+    "download-mp3": "node tools/mp3/download.js"
   },
   "dependencies": {
     "@emotion/react": "^11.14.0",
@@ -60,7 +61,10 @@
     "zustand": "^4.4.1",
     "socket.io": "^4.7.2",
     "socket.io-client": "^4.7.2",
-    "ioredis": "^5.3.2"
+    "ioredis": "^5.3.2",
+    "ytdl-core": "^4.11.3",
+    "fluent-ffmpeg": "^2.1.2",
+    "ffmpeg-static": "^5.1.0"
   },
   "devDependencies": {
     "@types/bcryptjs": "^2.4.6",

--- a/src/app/api/mp3/route.ts
+++ b/src/app/api/mp3/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from 'next/server';
+import path from 'path';
+const { downloadMP3 } = require(path.join(process.cwd(), 'tools/mp3/downloader'));
+
+export async function POST(request: Request) {
+  const { url } = await request.json();
+  if (!url) {
+    return NextResponse.json({ error: 'Missing url' }, { status: 400 });
+  }
+  try {
+    const output: string = await downloadMP3(url);
+    const filename = path.basename(output);
+    return NextResponse.json({ success: true, filename });
+  } catch (err: any) {
+    return NextResponse.json({ error: err.message || 'Download failed' }, { status: 500 });
+  }
+}

--- a/src/app/tools/mp3/page.tsx
+++ b/src/app/tools/mp3/page.tsx
@@ -1,0 +1,47 @@
+'use client';
+import { useState } from 'react';
+
+export default function Mp3Page() {
+  const [url, setUrl] = useState('');
+  const [status, setStatus] = useState('');
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setStatus('Downloading...');
+    try {
+      const res = await fetch('/api/mp3', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ url }),
+      });
+      const data = await res.json();
+      if (res.ok) {
+        setStatus('Saved ' + data.filename);
+      } else {
+        setStatus(data.error || 'Error');
+      }
+    } catch (err) {
+      setStatus('Error');
+    }
+  };
+
+  return (
+    <div className="p-4">
+      <h1 className="text-xl font-bold mb-4">YouTube MP3 татагч</h1>
+      <form onSubmit={handleSubmit} className="space-x-2">
+        <input
+          type="url"
+          value={url}
+          onChange={(e) => setUrl(e.target.value)}
+          placeholder="YouTube линк"
+          className="border px-2 py-1"
+          required
+        />
+        <button type="submit" className="bg-blue-600 text-white px-3 py-1 rounded">
+          Tatakh
+        </button>
+      </form>
+      {status && <p className="mt-4">{status}</p>}
+    </div>
+  );
+}

--- a/tools/mp3/download.js
+++ b/tools/mp3/download.js
@@ -1,0 +1,18 @@
+const { downloadMP3 } = require('./downloader');
+
+async function main() {
+  const url = process.argv[2];
+  if (!url) {
+    console.error('Usage: node download.js <youtube-url>');
+    process.exit(1);
+  }
+  try {
+    const output = await downloadMP3(url);
+    console.log('Saved:', output);
+  } catch (err) {
+    console.error('Error:', err.message || err);
+    process.exit(1);
+  }
+}
+
+main();

--- a/tools/mp3/downloader.js
+++ b/tools/mp3/downloader.js
@@ -1,0 +1,26 @@
+const ytdl = require('ytdl-core');
+const ffmpeg = require('fluent-ffmpeg');
+const ffmpegPath = require('ffmpeg-static');
+const path = require('path');
+
+async function downloadMP3(url) {
+  const info = await ytdl.getInfo(url);
+  const title = info.videoDetails.title
+    .replace(/[\\/:*?"<>|]/g, '')
+    .replace(/\s+/g, '_');
+  const output = path.join(__dirname, `${title}.mp3`);
+
+  await new Promise((resolve, reject) => {
+    ffmpeg(ytdl(url, { filter: 'audioonly', quality: 'highestaudio' }))
+      .setFfmpegPath(ffmpegPath)
+      .format('mp3')
+      .audioBitrate(128)
+      .on('error', reject)
+      .on('end', resolve)
+      .save(output);
+  });
+
+  return output;
+}
+
+module.exports = { downloadMP3 };


### PR DESCRIPTION
## Summary
- refactor mp3 downloader into reusable module
- expose mp3 download API route
- create `/tools/mp3` page to trigger download from browser
- document new page in README
- fix mp3 API import path

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cef1efa4c8328b1815314cca69a8e